### PR TITLE
Routing service test

### DIFF
--- a/RouterServiceTests.cs
+++ b/RouterServiceTests.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-public class RouterServiceTests : IAsyncLifetime
-{
-	public RouterServiceTests()
-	{
-	}
-}

--- a/RouterServiceTests.cs
+++ b/RouterServiceTests.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+public class RouterServiceTests : IAsyncLifetime
+{
+	public RouterServiceTests()
+	{
+	}
+}

--- a/src/AgentFramework.AspNetCore/Configuration/Service/ServiceBuilderExtensions.cs
+++ b/src/AgentFramework.AspNetCore/Configuration/Service/ServiceBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using AgentFramework.AspNetCore.Runtime;
+﻿using System.Net.Http;
+using AgentFramework.AspNetCore.Runtime;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Runtime;
 using Microsoft.Extensions.Caching.Memory;
@@ -19,6 +20,7 @@ namespace AgentFramework.AspNetCore.Configuration.Service
             builder.Services.TryAddSingleton<IProofService, DefaultProofService>();
             builder.Services.TryAddSingleton<IProvisioningService, DefaultProvisioningService>();
             builder.Services.TryAddSingleton<IRouterService, DefaultRouterService>();
+            builder.Services.TryAddSingleton<HttpClient>();
             builder.Services.TryAddSingleton<ISchemaService, DefaultSchemaService>();
             builder.Services.TryAddSingleton<ITailsService, DefaultTailsService>();
             builder.Services.TryAddSingleton<IWalletRecordService, DefaultWalletRecordService>();

--- a/src/AgentFramework.Core/Contracts/IRouterService.cs
+++ b/src/AgentFramework.Core/Contracts/IRouterService.cs
@@ -17,7 +17,7 @@ namespace AgentFramework.Core.Contracts
         /// <param name="message">The message.</param>
         /// <param name="connection">The connection record.</param>
         /// <param name="recipientKey">The recipients verkey to encrypt the message for.</param>
-        /// <returns></returns>
+        /// <returns>The response async.</returns>
         Task SendAsync(Wallet wallet, IAgentMessage message, ConnectionRecord connection, string recipientKey = null);
     }
 }

--- a/src/AgentFramework.Core/Messages/AgentMessageConverter.cs
+++ b/src/AgentFramework.Core/Messages/AgentMessageConverter.cs
@@ -2,6 +2,7 @@
 using AgentFramework.Core.Messages.Connections;
 using AgentFramework.Core.Messages.Credentials;
 using AgentFramework.Core.Messages.Proofs;
+using AgentFramework.Core.Messages.Routing;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -28,6 +29,9 @@ namespace AgentFramework.Core.Messages
             IAgentMessage message;
             switch (item["@type"].ToString())
             {
+                case MessageTypes.Forward:
+                    message = new ForwardMessage();
+                    break;
                 case MessageTypes.ConnectionInvitation:
                     message = new ConnectionInvitationMessage();
                     break;

--- a/src/AgentFramework.Core/Runtime/DefaultRouterService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultRouterService.cs
@@ -23,11 +23,11 @@ namespace AgentFramework.Core.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="T:AgentFramework.Core.Runtime.DefaultRouterService"/> class.
         /// </summary>
-        public DefaultRouterService(IMessageSerializer messageSerializer, ILogger<DefaultRouterService> logger)
+        public DefaultRouterService(IMessageSerializer messageSerializer, ILogger<DefaultRouterService> logger, HttpClient httpClient)
         {
             _messageSerializer = messageSerializer;
             _logger = logger;
-            _httpClient = new HttpClient();
+            _httpClient = httpClient;
         }
 
         /// <inheritdoc />

--- a/src/AgentFramework.Core/Runtime/DefaultRouterService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultRouterService.cs
@@ -18,7 +18,7 @@ namespace AgentFramework.Core.Runtime
     {
         private readonly IMessageSerializer _messageSerializer;
         private readonly ILogger<DefaultRouterService> _logger;
-        private readonly HttpClient _httpClient;
+        private readonly HttpClient _httpClient; 
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:AgentFramework.Core.Runtime.DefaultRouterService"/> class.
@@ -39,9 +39,9 @@ namespace AgentFramework.Core.Runtime
 
             //Create a wire message for the destination agent
             if (string.IsNullOrEmpty(recipientKey))
-                wireMessage = await _messageSerializer.AuthPackAsync(wallet, message, connectionRecord.TheirVk, connectionRecord.MyVk);
+                wireMessage = await _messageSerializer.AuthPackAsync(wallet, message, connectionRecord.MyVk, connectionRecord.TheirVk);
             else
-                wireMessage = await _messageSerializer.AuthPackAsync(wallet, message, recipientKey, connectionRecord.MyVk);
+                wireMessage = await _messageSerializer.AuthPackAsync(wallet, message, connectionRecord.MyVk, recipientKey);
 
             var innerMessage = Convert.ToBase64String(wireMessage);
 

--- a/test/AgentFramework.Core.Tests/RouterServiceTests.cs
+++ b/test/AgentFramework.Core.Tests/RouterServiceTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AgentFramework.Core.Contracts;
+using AgentFramework.Core.Messages;
+using AgentFramework.Core.Messages.Connections;
+using AgentFramework.Core.Messages.Routing;
+using AgentFramework.Core.Models;
+using AgentFramework.Core.Models.Connections;
+using AgentFramework.Core.Models.Records;
+using AgentFramework.Core.Runtime;
+using Hyperledger.Indy.DidApi;
+using Hyperledger.Indy.WalletApi;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace AgentFramework.Core.Tests
+{
+    public class RouterServiceTests : IAsyncLifetime
+    {
+        private const string HolderConfig = "{\"id\":\"holder_proof_test_wallet\"}";
+        private const string WalletCredentials = "{\"key\":\"test_wallet_key\"}";
+
+        private Wallet _wallet;
+
+        private readonly IRouterService _routerService;
+        private readonly IMessageSerializer _messageSerializer;
+
+        private readonly ConcurrentBag<HttpRequestMessage> _messages = new ConcurrentBag<HttpRequestMessage>();
+
+        public RouterServiceTests()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+                .Protected()
+                // Setup the PROTECTED method to mock
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                // prepare the expected response of the mocked http call
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(""),
+                })
+                .Callback((HttpRequestMessage request, CancellationToken cancellationToken) =>
+                {
+                    _messages.Add(request);
+                })
+                .Verifiable();
+
+            // use real http client with mocked handler here
+            var httpClient = new HttpClient(handlerMock.Object);
+
+            _messageSerializer = new DefaultMessageSerializer();
+
+            _routerService = new DefaultRouterService(_messageSerializer,
+                new Mock<ILogger<DefaultRouterService>>().Object, httpClient);
+        }
+
+        public async Task InitializeAsync()
+        {
+            try
+            {
+                await Wallet.CreateWalletAsync(HolderConfig, WalletCredentials);
+            }
+            catch (WalletExistsException)
+            {
+                // OK
+            }
+
+            _wallet = await Wallet.OpenWalletAsync(HolderConfig, WalletCredentials);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_wallet != null) await _wallet.CloseAsync();
+            await Wallet.DeleteWalletAsync(HolderConfig, WalletCredentials);
+        }
+
+        [Fact]
+        public async Task CanSendMessage()
+        {
+            var my = await Did.CreateAndStoreMyDidAsync(_wallet, "{}");
+            var their = await Did.CreateAndStoreMyDidAsync(_wallet, "{}");
+            var agency = await Did.CreateAndStoreMyDidAsync(_wallet, "{}");
+
+            var connection = new ConnectionRecord
+            {
+                MyDid = my.Did,
+                MyVk = my.VerKey,
+                Alias = new ConnectionAlias
+                {
+                    Name = "Test"
+                },
+                Endpoint = new AgentEndpoint
+                {
+                    Uri = "https://mock.com",
+                    Verkey = agency.VerKey
+                },
+                TheirDid = their.Did,
+                TheirVk = their.VerKey
+            };
+
+            await _routerService.SendAsync(_wallet, new ConnectionRequestMessage(), connection);
+
+            var httpMessage = _messages.FirstOrDefault();
+
+            Assert.True(httpMessage != null);
+
+            Assert.True(httpMessage.Method == HttpMethod.Post);
+            Assert.True(httpMessage.RequestUri == new Uri("https://mock.com"));
+            Assert.True(httpMessage.Content.Headers.ContentType.ToString() == "application/octet-stream");
+
+            byte[] body = await httpMessage.Content.ReadAsByteArrayAsync();
+
+            var outerMessage = await _messageSerializer.AnonUnpackAsync(body, _wallet);
+
+            var forwardMessage = outerMessage as ForwardMessage ?? 
+                throw new Exception("Expected inner message to be of type 'ForwardMessage'");
+
+            var innerMessageContents = Convert.FromBase64String(forwardMessage.Message);
+
+            (var message, _, var theirKey) =
+                await _messageSerializer.AuthUnpackAsync(innerMessageContents, _wallet);
+
+            Assert.True(message.Type == MessageTypes.ConnectionRequest);
+            Assert.True(their.VerKey == theirKey);
+        }
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Wraps a test around the routing service.

#### Changes proposed in this pull request:

- Allows injection of the HttpClient allowing the DefaultRoutingService to be mocked.
- Adds a test class for the routing service.