### PR TITLE
Fix for WalletService.GetWalletAsync() invalid wallet handles being cached

### DIFF
--- a/test/AgentFramework.Core.Tests/WalletTests.cs
+++ b/test/AgentFramework.Core.Tests/WalletTests.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using AgentFramework.Core.Models.Wallets;
 using AgentFramework.Core.Runtime;
+using Hyperledger.Indy.WalletApi;
 using Xunit;
 
 namespace AgentFramework.Core.Tests
@@ -36,6 +35,88 @@ namespace AgentFramework.Core.Tests
             Assert.NotNull(provisioning.Endpoint);
             Assert.NotNull(provisioning.Endpoint.Did);
             Assert.NotNull(provisioning.Endpoint.Verkey);
+        }
+
+        [Fact]
+        public async Task CanCreateAndGetWallet()
+        {
+            var config = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+            var creds = new WalletCredentials { Key = "1" };
+
+            var walletService = new DefaultWalletService();
+
+            await walletService.CreateWalletAsync(config, creds);
+
+            var wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+        }
+
+        [Fact]
+        public async Task CanCreateGetAndCloseWallet()
+        {
+            var config = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+            var creds = new WalletCredentials { Key = "1" };
+
+            var walletService = new DefaultWalletService();
+
+            await walletService.CreateWalletAsync(config, creds);
+
+            var wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+
+            await wallet.CloseAsync();
+
+            wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+        }
+
+        [Fact]
+        public async Task CanCreateGetAndDisposeWallet()
+        {
+            var config = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+            var creds = new WalletCredentials { Key = "1" };
+
+            var walletService = new DefaultWalletService();
+
+            await walletService.CreateWalletAsync(config, creds);
+
+            var wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+
+            wallet.Dispose();
+
+            wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+        }
+
+        [Fact]
+        public async Task CanCreateGetAndDeleteWallet()
+        {
+            var config = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+            var creds = new WalletCredentials { Key = "1" };
+
+            var walletService = new DefaultWalletService();
+
+            await walletService.CreateWalletAsync(config, creds);
+
+            var wallet = await walletService.GetWalletAsync(config, creds);
+
+            Assert.NotNull(wallet);
+            Assert.True(wallet.IsOpen);
+            
+            await walletService.DeleteWalletAsync(config, creds);
+
+            await Assert.ThrowsAsync<WalletNotFoundException>(() => walletService.GetWalletAsync(config, creds));
         }
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Prevents the ability of resolving cached wallet objects from the wallet service which are in an invalid state.

#### Changes proposed in this pull request:

- Leverage the new .IsOpen flag on the wallet object to decided whether to retain the wallet object in cache or flush and create a new connection.
- Close and dispose of wallet object prior to deleting a wallet.
- Test cases for the above changes.

**Fixes**: #61 
