### PR TITLE
Support for multi-party connection invitations

### DIFF
--- a/src/AgentFramework.Core/Contracts/IConnectionService.cs
+++ b/src/AgentFramework.Core/Contracts/IConnectionService.cs
@@ -49,7 +49,7 @@ namespace AgentFramework.Core.Contracts
         /// <exception cref="AgentFrameworkException">Throws with ErrorCode.RecordNotFound.</exception>
         /// <exception cref="AgentFrameworkException">Throws with ErrorCode.RecordInInvalidState.</exception>
         /// <returns>The async.</returns>
-        Task RevokeInvitation(Wallet wallet, string invitationId);
+        Task RevokeInvitationAsync(Wallet wallet, string invitationId);
 
         /// <summary>
         /// Accepts the connection invitation async.

--- a/src/AgentFramework.Core/Contracts/IConnectionService.cs
+++ b/src/AgentFramework.Core/Contracts/IConnectionService.cs
@@ -38,8 +38,18 @@ namespace AgentFramework.Core.Contracts
         /// </summary>
         /// <param name="wallet">Wallet.</param>
         /// <param name="config">An optional configuration object used to configure the resulting invitations presentation</param>
-        /// <returns></returns>
+        /// <returns>The async.</returns>
         Task<ConnectionInvitationMessage> CreateInvitationAsync(Wallet wallet, InviteConfiguration config = null);
+
+        /// <summary>
+        /// Revokes an invitation.
+        /// </summary>
+        /// <param name="wallet">Wallet.</param>
+        /// <param name="invitationId">Id of the invitation.</param>
+        /// <exception cref="AgentFrameworkException">Throws with ErrorCode.RecordNotFound.</exception>
+        /// <exception cref="AgentFrameworkException">Throws with ErrorCode.RecordInInvalidState.</exception>
+        /// <returns>The async.</returns>
+        Task RevokeInvitation(Wallet wallet, string invitationId);
 
         /// <summary>
         /// Accepts the connection invitation async.

--- a/src/AgentFramework.Core/Extensions/ConnectionServiceExtensions.cs
+++ b/src/AgentFramework.Core/Extensions/ConnectionServiceExtensions.cs
@@ -50,7 +50,21 @@ namespace AgentFramework.Core.Extensions
         public static Task<List<ConnectionRecord>> ListInvitedConnectionsAsync(
             this IConnectionService connectionService, Wallet wallet, int count = 100)
             => connectionService.ListAsync(wallet,
-                SearchQuery.Equal(nameof(ConnectionRecord.State), ConnectionState.Invited.ToString("G")), count);
+                SearchQuery.And(SearchQuery.Equal(nameof(ConnectionRecord.State), ConnectionState.Invited.ToString("G")),
+                                SearchQuery.Equal(nameof(ConnectionRecord.MultiPartyInvitation), false.ToString())), count);
+
+        /// <summary>
+        /// Retrieves a list of <see cref="ConnectionRecord"/> that are multi-party invitations.
+        /// </summary>
+        /// <returns>The invited connections async.</returns>
+        /// <param name="connectionService">Connection service.</param>
+        /// <param name="wallet">Wallet.</param>
+        /// <param name="count">Count.</param>
+        public static Task<List<ConnectionRecord>> ListMultiPartyInvitationsAsync(
+            this IConnectionService connectionService, Wallet wallet, int count = 100)
+            => connectionService.ListAsync(wallet,
+                SearchQuery.And(SearchQuery.Equal(nameof(ConnectionRecord.State), ConnectionState.Invited.ToString("G")),
+                    SearchQuery.Equal(nameof(ConnectionRecord.MultiPartyInvitation), true.ToString())), count);
 
         /// <summary>
         /// Retrieves a <see cref="ConnectionRecord"/> by key.

--- a/src/AgentFramework.Core/Models/Connections/InviteConfiguration.cs
+++ b/src/AgentFramework.Core/Models/Connections/InviteConfiguration.cs
@@ -14,6 +14,12 @@ namespace AgentFramework.Core.Models.Connections
         public string ConnectionId { get; set; }
 
         /// <summary>
+        /// Used to generated an invitation that multiple parties
+        /// can use to connect.
+        /// </summary>
+        public bool MultiPartyInvitation { get; set; }
+
+        /// <summary>
         /// Alias object for marking the invite subject
         /// with an alias for giving the inviter greater context. 
         /// </summary>

--- a/src/AgentFramework.Core/Models/Records/ConnectionRecord.cs
+++ b/src/AgentFramework.Core/Models/Records/ConnectionRecord.cs
@@ -95,6 +95,17 @@ namespace AgentFramework.Core.Models.Records
         }
 
         /// <summary>
+        /// Gets or sets whether the invitation is multi-party.
+        /// </summary>
+        /// <value>Indicates if the property is multi-party.</value>
+        [JsonIgnore]
+        public bool MultiPartyInvitation
+        {
+            get => GetBool();
+            set => Set(value);
+        }
+
+        /// <summary>
         /// Gets or sets the alias associated to the connection.
         /// </summary>
         /// <value>The connection alias.</value>

--- a/src/AgentFramework.Core/Models/Records/RecordBase.cs
+++ b/src/AgentFramework.Core/Models/Records/RecordBase.cs
@@ -215,5 +215,15 @@ namespace AgentFramework.Core.Models.Records
 
             return new DateTime(Convert.ToInt64(strVal));
         }
+
+        protected bool GetBool(bool encrypted = true, [CallerMemberName] string name = "")
+        {
+            var strVal = Get(encrypted, name);
+
+            if (strVal == null)
+                return false;
+
+            return Convert.ToBoolean(strVal);
+        }
     }
 }

--- a/src/AgentFramework.Core/Runtime/DefaultConnectionService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultConnectionService.cs
@@ -102,6 +102,18 @@ namespace AgentFramework.Core.Runtime
         }
 
         /// <inheritdoc />
+        public async Task RevokeInvitation(Wallet wallet, string invitationId)
+        {
+            var connection = await GetAsync(wallet, invitationId);
+
+            if (connection.State != ConnectionState.Invited)
+                throw new AgentFrameworkException(ErrorCode.RecordInInvalidState,
+                    $"Connection state was invalid. Expected '{ConnectionState.Invited}', found '{connection.State}'");
+
+            await RecordService.DeleteAsync<ConnectionRecord>(wallet, invitationId);
+        }
+
+        /// <inheritdoc />
         public virtual async Task<string> AcceptInvitationAsync(Wallet wallet, ConnectionInvitationMessage invitation)
         {
             Logger.LogInformation(LoggingEvents.AcceptInvitation, "Key {0}, Endpoint {1}",

--- a/src/AgentFramework.Core/Runtime/DefaultConnectionService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultConnectionService.cs
@@ -102,7 +102,7 @@ namespace AgentFramework.Core.Runtime
         }
 
         /// <inheritdoc />
-        public async Task RevokeInvitation(Wallet wallet, string invitationId)
+        public async Task RevokeInvitationAsync(Wallet wallet, string invitationId)
         {
             var connection = await GetAsync(wallet, invitationId);
 
@@ -197,7 +197,6 @@ namespace AgentFramework.Core.Runtime
 
             var newConnection = connection.DeepCopy();
             newConnection.Id = Guid.NewGuid().ToString();
-            newConnection.MultiPartyInvitation = false;
             await newConnection.TriggerAsync(ConnectionTrigger.InvitationAccept);
             await RecordService.AddAsync(wallet, newConnection);
             return newConnection.Id;

--- a/src/AgentFramework.Core/Runtime/DefaultCredentialService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultCredentialService.cs
@@ -57,7 +57,7 @@ namespace AgentFramework.Core.Runtime
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCredentialService"/> class.
         /// </summary>
-        /// <param name="routerService">The router service.</param>
+        /// <param name="messageService">The message service.</param>
         /// <param name="ledgerService">The ledger service.</param>
         /// <param name="connectionService">The connection service.</param>
         /// <param name="recordService">The record service.</param>

--- a/src/AgentFramework.Core/Runtime/DefaultProofService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultProofService.cs
@@ -59,7 +59,7 @@ namespace AgentFramework.Core.Runtime
         /// Initializes a new instance of the <see cref="DefaultProofService"/> class.
         /// </summary>
         /// <param name="connectionService">The connection service.</param>
-        /// <param name="routerService">The router service.</param>
+        /// <param name="messageService">The message service.</param>
         /// <param name="recordService">The record service.</param>
         /// <param name="provisioningService">The provisioning service.</param>
         /// <param name="ledgerService">The ledger service.</param>

--- a/test/AgentFramework.Core.Tests/ConnectionTests.cs
+++ b/test/AgentFramework.Core.Tests/ConnectionTests.cs
@@ -219,7 +219,7 @@ namespace AgentFramework.Core.Tests
         [Fact]
         public async Task RevokeInvitationThrowsConnectionNotFound()
         {
-            var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () => await _connectionService.RevokeInvitation(_issuerWallet, "bad-connection-id"));
+            var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () => await _connectionService.RevokeInvitationAsync(_issuerWallet, "bad-connection-id"));
             Assert.True(ex.ErrorCode == ErrorCode.RecordNotFound);
         }
 
@@ -250,7 +250,7 @@ namespace AgentFramework.Core.Tests
             await _connectionService.AcceptRequestAsync(_issuerWallet, connectionId);
 
             //Now try and revoke invitation
-            var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () => await _connectionService.RevokeInvitation(_issuerWallet, connectionId));
+            var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () => await _connectionService.RevokeInvitationAsync(_issuerWallet, connectionId));
 
             Assert.True(ex.ErrorCode == ErrorCode.RecordInInvalidState);
         }
@@ -269,7 +269,7 @@ namespace AgentFramework.Core.Tests
             Assert.Equal(ConnectionState.Invited, connection.State);
             Assert.Equal(connectionId, connection.Id);
 
-            await _connectionService.RevokeInvitation(_issuerWallet, connectionId);
+            await _connectionService.RevokeInvitationAsync(_issuerWallet, connectionId);
 
             var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () => await _connectionService.AcceptRequestAsync(_issuerWallet, connectionId));
             Assert.True(ex.ErrorCode == ErrorCode.RecordNotFound);

--- a/test/AgentFramework.Core.Tests/ConnectionTests.cs
+++ b/test/AgentFramework.Core.Tests/ConnectionTests.cs
@@ -20,6 +20,7 @@ namespace AgentFramework.Core.Tests
     {
         private readonly string _issuerConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}"; 
         private readonly string _holderConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
+        private readonly string _holderConfigTwo = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
         private const string Credentials = "{\"key\":\"test_wallet_key\"}";
         private const string MockEndpointUri = "http://mock";
         
@@ -27,6 +28,7 @@ namespace AgentFramework.Core.Tests
 
         private Wallet _issuerWallet;
         private Wallet _holderWallet;
+        private Wallet _holderWalletTwo;
 
         private readonly IConnectionService _connectionService;
 
@@ -81,8 +83,18 @@ namespace AgentFramework.Core.Tests
                 // OK
             }
 
+            try
+            {
+                await Wallet.CreateWalletAsync(_holderConfigTwo, Credentials);
+            }
+            catch (WalletExistsException)
+            {
+                // OK
+            }
+
             _issuerWallet = await Wallet.OpenWalletAsync(_issuerConfig, Credentials);
             _holderWallet = await Wallet.OpenWalletAsync(_holderConfig, Credentials);
+            _holderWalletTwo = await Wallet.OpenWalletAsync(_holderConfigTwo, Credentials);
         }
 
         [Fact]
@@ -90,11 +102,27 @@ namespace AgentFramework.Core.Tests
         {
             var connectionId = Guid.NewGuid().ToString();
 
-            var invitation = await _connectionService.CreateInvitationAsync(_issuerWallet,
+            await _connectionService.CreateInvitationAsync(_issuerWallet,
                 new InviteConfiguration() {ConnectionId = connectionId});
 
             var connection = await _connectionService.GetAsync(_issuerWallet, connectionId);
 
+            Assert.False(connection.MultiPartyInvitation);
+            Assert.Equal(ConnectionState.Invited, connection.State);
+            Assert.Equal(connectionId, connection.Id);
+        }
+
+        [Fact]
+        public async Task CanCreateMultiPartyInvitationAsync()
+        {
+            var connectionId = Guid.NewGuid().ToString();
+
+            await _connectionService.CreateInvitationAsync(_issuerWallet,
+                new InviteConfiguration() { ConnectionId = connectionId, MultiPartyInvitation = true });
+
+            var connection = await _connectionService.GetAsync(_issuerWallet, connectionId);
+
+            Assert.True(connection.MultiPartyInvitation);
             Assert.Equal(ConnectionState.Invited, connection.State);
             Assert.Equal(connectionId, connection.Id);
         }
@@ -156,7 +184,6 @@ namespace AgentFramework.Core.Tests
         [Fact]
         public async Task AcceptRequestThrowsExceptionUnableToSendA2AMessage()
         {
-            
             var connectionId = Guid.NewGuid().ToString();
             
             await _connectionService.CreateInvitationAsync(_issuerWallet,
@@ -204,14 +231,49 @@ namespace AgentFramework.Core.Tests
             Assert.Equal(connectionIssuer.Endpoint.Uri, MockEndpointUri);
             Assert.Equal(connectionIssuer.Endpoint.Uri, MockEndpointUri);
         }
-         
+
+        [Fact]
+        public async Task CanEstablishConnectionsWithMultiPartyInvitationAsync()
+        {
+            var connectionId = Guid.NewGuid().ToString();
+
+            var invite = await _connectionService.CreateInvitationAsync(_issuerWallet,
+                new InviteConfiguration() { ConnectionId = connectionId, MultiPartyInvitation = true });
+
+            var (connectionIssuer, connectionHolderOne) = await Scenarios.EstablishConnectionAsync(
+                _connectionService, _messages, _issuerWallet, _holderWallet, invite, connectionId);
+
+            var (connectionIssuerTwo, connectionHolderTwo) = await Scenarios.EstablishConnectionAsync(
+                _connectionService, _messages, _issuerWallet, _holderWalletTwo, invite, connectionId);
+
+            Assert.Equal(ConnectionState.Connected, connectionIssuer.State);
+            Assert.Equal(ConnectionState.Connected, connectionHolderOne.State);
+
+            Assert.Equal(ConnectionState.Connected, connectionIssuerTwo.State);
+            Assert.Equal(ConnectionState.Connected, connectionHolderTwo.State);
+
+            Assert.Equal(connectionIssuer.MyDid, connectionHolderOne.TheirDid);
+            Assert.Equal(connectionIssuer.TheirDid, connectionHolderOne.MyDid);
+
+            Assert.Equal(connectionIssuerTwo.MyDid, connectionHolderTwo.TheirDid);
+            Assert.Equal(connectionIssuerTwo.TheirDid, connectionHolderTwo.MyDid);
+
+            Assert.Equal(connectionIssuer.Endpoint.Uri, MockEndpointUri);
+            Assert.Equal(connectionIssuer.Endpoint.Uri, MockEndpointUri);
+
+            Assert.Equal(connectionIssuerTwo.Endpoint.Uri, MockEndpointUri);
+            Assert.Equal(connectionIssuerTwo.Endpoint.Uri, MockEndpointUri);
+        }
+
         public async Task DisposeAsync()
         {
             if (_issuerWallet != null) await _issuerWallet.CloseAsync();
             if (_holderWallet != null) await _holderWallet.CloseAsync();
+            if (_holderWalletTwo != null) await _holderWalletTwo.CloseAsync();
 
             await Wallet.DeleteWalletAsync(_issuerConfig, Credentials);
             await Wallet.DeleteWalletAsync(_holderConfig, Credentials);
+            await Wallet.DeleteWalletAsync(_holderConfigTwo, Credentials);
         }
     }
 }

--- a/test/AgentFramework.Core.Tests/ConnectionTests.cs
+++ b/test/AgentFramework.Core.Tests/ConnectionTests.cs
@@ -318,9 +318,6 @@ namespace AgentFramework.Core.Tests
             Assert.Equal(connectionIssuerTwo.TheirDid, connectionHolderTwo.MyDid);
 
             Assert.Equal(connectionIssuer.Endpoint.Uri, MockEndpointUri);
-            Assert.Equal(connectionIssuer.Endpoint.Uri, MockEndpointUri);
-
-            Assert.Equal(connectionIssuerTwo.Endpoint.Uri, MockEndpointUri);
             Assert.Equal(connectionIssuerTwo.Endpoint.Uri, MockEndpointUri);
         }
 

--- a/test/AgentFramework.Core.Tests/MockExtendedConnectionService.cs
+++ b/test/AgentFramework.Core.Tests/MockExtendedConnectionService.cs
@@ -26,7 +26,7 @@ namespace AgentFramework.Core.Tests
             throw new System.NotImplementedException();
         }
 
-        public Task RevokeInvitation(Wallet wallet, string invitationId)
+        public Task RevokeInvitationAsync(Wallet wallet, string invitationId)
         {
             throw new System.NotImplementedException();
         }

--- a/test/AgentFramework.Core.Tests/MockExtendedConnectionService.cs
+++ b/test/AgentFramework.Core.Tests/MockExtendedConnectionService.cs
@@ -26,6 +26,11 @@ namespace AgentFramework.Core.Tests
             throw new System.NotImplementedException();
         }
 
+        public Task RevokeInvitation(Wallet wallet, string invitationId)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task<string> AcceptInvitationAsync(Wallet wallet, ConnectionInvitationMessage offer)
         {
             throw new System.NotImplementedException();


### PR DESCRIPTION
#### Short description of what this resolves:

Adds support for multi-party invitations in the connection protocol.

#### Changes proposed in this pull request:

- Expands invitation configuration to have a new MultiPartyInvitation property for controlling invitation generation.
- Adds the MultiPartyInvitation property to the ConnectionRecord.
- Adds two new tests for creating a multi party invitation and connecting two parties two an invitee from a single invite
- Adds an extension method to fetch multi-party invitations.
- Filters out multi-party invitations from the ListInvitedConnectionsAsync() extension method.
- Adds support for revoking an invitation.

**Fixes**: #92 
