### PR TITLE
Support for mandatory @id and @type fields on all agent messages.

### DIFF
--- a/src/AgentFramework.Core/Messages/Connections/ConnectionInvitationMessage.cs
+++ b/src/AgentFramework.Core/Messages/Connections/ConnectionInvitationMessage.cs
@@ -1,4 +1,5 @@
-﻿using AgentFramework.Core.Models;
+﻿using System;
+using AgentFramework.Core.Models;
 using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Connections
@@ -8,6 +9,14 @@ namespace AgentFramework.Core.Messages.Connections
     /// </summary>
     public class ConnectionInvitationMessage : IAgentMessage
     {
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
+        [JsonProperty("@type")]
+        public string Type { get; set; } = MessageTypes.ConnectionInvitation;
+
         /// <summary>
         /// Gets or sets the endpoint.
         /// </summary>
@@ -43,14 +52,5 @@ namespace AgentFramework.Core.Messages.Connections
         /// </value>
         [JsonProperty("connectionKey")]
         public string ConnectionKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
-        [JsonProperty("@type")]
-        public string Type { get; set; } = MessageTypes.ConnectionInvitation;
     }
 }

--- a/src/AgentFramework.Core/Messages/Connections/ConnectionRequestMessage.cs
+++ b/src/AgentFramework.Core/Messages/Connections/ConnectionRequestMessage.cs
@@ -1,4 +1,5 @@
-﻿using AgentFramework.Core.Models;
+﻿using System;
+using AgentFramework.Core.Models;
 using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Connections
@@ -8,6 +9,14 @@ namespace AgentFramework.Core.Messages.Connections
     /// </summary>
     public class ConnectionRequestMessage : IAgentMessage
     {
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
+        [JsonProperty("@type")]
+        public string Type { get; set; } = MessageTypes.ConnectionRequest;
+
         /// <summary>
         /// Gets or sets the did.
         /// </summary>
@@ -34,15 +43,6 @@ namespace AgentFramework.Core.Messages.Connections
         /// </value>
         [JsonProperty("endpoint")]
         public AgentEndpoint Endpoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
-        [JsonProperty("@type")]
-        public string Type { get; set; } = MessageTypes.ConnectionRequest;
 
         /// <summary>
         /// Gets or sets the image URL.

--- a/src/AgentFramework.Core/Messages/Connections/ConnectionResponseMessage.cs
+++ b/src/AgentFramework.Core/Messages/Connections/ConnectionResponseMessage.cs
@@ -1,4 +1,5 @@
-﻿using AgentFramework.Core.Models;
+﻿using System;
+using AgentFramework.Core.Models;
 using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Connections
@@ -8,6 +9,14 @@ namespace AgentFramework.Core.Messages.Connections
     /// </summary>
     public class ConnectionResponseMessage : IAgentMessage
     {
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
+        [JsonProperty("@type")]
+        public string Type { get; set; } = MessageTypes.ConnectionResponse;
+
         /// <summary>
         /// Gets or sets the did.
         /// </summary>
@@ -34,14 +43,5 @@ namespace AgentFramework.Core.Messages.Connections
         /// </value>
         [JsonProperty("endpoint")]
         public AgentEndpoint Endpoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
-        [JsonProperty("@type")]
-        public string Type { get; set; } = MessageTypes.ConnectionResponse;
     }
 }

--- a/src/AgentFramework.Core/Messages/Credentials/CredentialMessage.cs
+++ b/src/AgentFramework.Core/Messages/Credentials/CredentialMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Credentials
 {
@@ -7,12 +8,11 @@ namespace AgentFramework.Core.Messages.Credentials
     /// </summary>
     public class CredentialMessage : IAgentMessage
     {
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
         [JsonProperty("@type")]
         public string Type { get; set; } = MessageTypes.Credential;
 

--- a/src/AgentFramework.Core/Messages/Credentials/CredentialOfferMessage.cs
+++ b/src/AgentFramework.Core/Messages/Credentials/CredentialOfferMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Credentials
 {
@@ -7,12 +8,11 @@ namespace AgentFramework.Core.Messages.Credentials
     /// </summary>
     public class CredentialOfferMessage : IAgentMessage
     {
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
         [JsonProperty("@type")]
         public string Type { get; set; } = MessageTypes.CredentialOffer;
 

--- a/src/AgentFramework.Core/Messages/Credentials/CredentialRequestMessage.cs
+++ b/src/AgentFramework.Core/Messages/Credentials/CredentialRequestMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Credentials
 {
@@ -7,15 +8,14 @@ namespace AgentFramework.Core.Messages.Credentials
     /// </summary>
     public class CredentialRequestMessage : IAgentMessage
     {
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
         [JsonProperty("@type")]
         public string Type { get; set; } = MessageTypes.CredentialRequest;
-
+        
         /// <summary>
         /// Gets or sets the offer json.
         /// </summary>

--- a/src/AgentFramework.Core/Messages/IAgentMessage.cs
+++ b/src/AgentFramework.Core/Messages/IAgentMessage.cs
@@ -8,6 +8,15 @@ namespace AgentFramework.Core.Messages
     public interface IAgentMessage
     {
         /// <summary>
+        /// Gets or sets the message id.
+        /// </summary>
+        /// <value>
+        /// The message id.
+        /// </value>
+        [JsonProperty("@id")]
+        string Id { get; set; }
+
+        /// <summary>
         /// Gets or sets the type.
         /// </summary>
         /// <value>

--- a/src/AgentFramework.Core/Messages/Proofs/ProofMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/ProofMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Proofs
 {
@@ -7,12 +8,11 @@ namespace AgentFramework.Core.Messages.Proofs
     /// </summary>
     public class ProofMessage : IAgentMessage
     {
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
         [JsonProperty("@type")]
         public string Type { get; set; } = MessageTypes.DisclosedProof;
 

--- a/src/AgentFramework.Core/Messages/Proofs/ProofRequestMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/ProofRequestMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Proofs
 {
@@ -7,12 +8,11 @@ namespace AgentFramework.Core.Messages.Proofs
     /// </summary>
     public class ProofRequestMessage : IAgentMessage
     {
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
         [JsonProperty("@type")]
         public string Type { get; set; } = MessageTypes.ProofRequest;
 

--- a/src/AgentFramework.Core/Messages/Routing/ForwardMessage.cs
+++ b/src/AgentFramework.Core/Messages/Routing/ForwardMessage.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace AgentFramework.Core.Messages.Routing
 {
@@ -7,12 +8,11 @@ namespace AgentFramework.Core.Messages.Routing
     /// </summary>
     public class ForwardMessage : IAgentMessage
     {
-        /// <summary>
-        /// Gets or sets the type.
-        /// </summary>
-        /// <value>
-        /// The type.
-        /// </value>
+        /// <inheritdoc />
+        [JsonProperty("@id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <inheritdoc />
         [JsonProperty("@type")]
         public string Type { get; set; } = MessageTypes.Forward;
 

--- a/src/AgentFramework.Core/Runtime/DefaultMessageService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultMessageService.cs
@@ -42,6 +42,12 @@ namespace AgentFramework.Core.Runtime
             Logger.LogInformation(LoggingEvents.SendMessage, "Recipient {0} Endpoint {1}", connectionRecord.TheirVk,
                 connectionRecord.Endpoint.Uri);
 
+            if (string.IsNullOrEmpty(message.Id))
+                throw new AgentFrameworkException(ErrorCode.InvalidMessage, "@id field on message must be populated");
+
+            if (string.IsNullOrEmpty(message.Type))
+                throw new AgentFrameworkException(ErrorCode.InvalidMessage, "@type field on message must be populated");
+
             var encryptionKey = recipientKey
                                 ?? connectionRecord.TheirVk
                                 ?? throw new AgentFrameworkException(

--- a/test/AgentFramework.Core.Tests/MessageServiceTests.cs
+++ b/test/AgentFramework.Core.Tests/MessageServiceTests.cs
@@ -28,6 +28,13 @@ using Xunit;
 
 namespace AgentFramework.Core.Tests
 {
+    public class MockAgentMessage : IAgentMessage
+    {
+        public string Id { get; set; }
+
+        public string Type { get; set; }
+    }
+
     public class MessageServiceTests : IAsyncLifetime
     {
         private string Config = "{\"id\":\"" + Guid.NewGuid() + "\"}";
@@ -239,6 +246,46 @@ namespace AgentFramework.Core.Tests
 
             if (dummyWallet != null) await dummyWallet.CloseAsync();
             await Wallet.DeleteWalletAsync(dummyConfig, WalletCredentials);
+        }
+
+        [Fact]
+        public async Task SendAsyncThrowsInvalidMessageNoId()
+        {
+            var connection = new ConnectionRecord
+            {
+                Alias = new ConnectionAlias
+                {
+                    Name = "Test"
+                },
+                Endpoint = new AgentEndpoint
+                {
+                    Uri = "https://mock.com"
+                },
+            };
+
+            var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () =>
+                await _messagingService.SendAsync(_wallet, new MockAgentMessage(), connection));
+            Assert.True(ex.ErrorCode == ErrorCode.InvalidMessage);
+        }
+
+        [Fact]
+        public async Task SendAsyncThrowsInvalidMessageNoType()
+        {
+            var connection = new ConnectionRecord
+            {
+                Alias = new ConnectionAlias
+                {
+                    Name = "Test"
+                },
+                Endpoint = new AgentEndpoint
+                {
+                    Uri = "https://mock.com"
+                },
+            };
+
+            var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () =>
+                await _messagingService.SendAsync(_wallet, new MockAgentMessage { Id = Guid.NewGuid().ToString() }, connection));
+            Assert.True(ex.ErrorCode == ErrorCode.InvalidMessage);
         }
 
         [Fact]


### PR DESCRIPTION
#### Short description of what this resolves:

Adds support for the @id field and enforces population on both fields for all outbound agent messages.

#### Changes proposed in this pull request:

- Adds @id field to all agent message.s
- Auto generation of new message id for all new agent messages.
- Enforces @id and @type field population on all outbound messages.
- Adds tests to check invalid outbound messages are identified by the message service.

**Related to**: #64 
