### PR TITLE
Add pack_unpack utils and unit tests

### DIFF
--- a/src/AgentFramework.Core/AgentFramework.Core.csproj
+++ b/src/AgentFramework.Core/AgentFramework.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Stateless" Version="4.2.1" />
-    <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.6.8" />
+    <PackageReference Include="Hyperledger.Indy.Sdk" Version="1.8.0" />
     <PackageReference Include="Multiformats.Base" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AgentFramework.Core/Utils/CryptoUtils.cs
+++ b/src/AgentFramework.Core/Utils/CryptoUtils.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using AgentFramework.Core.Extensions;
+using Hyperledger.Indy.CryptoApi;
+using Hyperledger.Indy.WalletApi;
+using Newtonsoft.Json;
+
+namespace AgentFramework.Core.Utils
+{
+    internal class CryptoUtils
+    {
+        /// <summary>Packs a message</summary>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="recipientKey">The recipient key.</param>
+        /// <param name="senderKey">The sender key.</param>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static Task<byte[]> PackAsync(
+            Wallet wallet, string recipientKey, string senderKey, byte[] message) =>
+            PackAsync(wallet, new[] {recipientKey}, senderKey, message);
+
+        /// <summary>Packs the asynchronous.</summary>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="recipientKeys">The recipient keys.</param>
+        /// <param name="senderKey">The sender key.</param>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static Task<byte[]> PackAsync(
+            Wallet wallet, string[] recipientKeys, string senderKey, byte[] message) =>
+            Crypto.PackMessageAsync(wallet, recipientKeys.ToJson(), senderKey, message);
+
+        /// <summary>Packs the asynchronous.</summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="recipientKey">The recipient key.</param>
+        /// <param name="senderKey">The sender key.</param>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static Task<byte[]> PackAsync<T>(
+            Wallet wallet, string recipientKey, string senderKey, T message) =>
+            PackAsync(wallet, new[] {recipientKey}, senderKey, message.ToByteArray());
+
+        /// <summary>Packs the asynchronous.</summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="recipientKeys">The recipient keys.</param>
+        /// <param name="senderKey">The sender key.</param>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static Task<byte[]> PackAsync<T>(
+            Wallet wallet, string[] recipientKeys, string senderKey, T message) =>
+            Crypto.PackMessageAsync(wallet, recipientKeys.ToJson(), senderKey, message.ToByteArray());
+
+        /// <summary>Unpacks the asynchronous.</summary>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static async Task<UnpackResult> UnpackAsync(Wallet wallet, byte[] message)
+        {
+            var result = await Crypto.UnpackMessageAsync(wallet, message);
+            return result.ToObject<UnpackResult>();
+        }
+
+        /// <summary>Unpacks the asynchronous.</summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="message">The message.</param>
+        /// <returns></returns>
+        public static async Task<T> UnpackAsync<T>(Wallet wallet, byte[] message)
+        {
+            var result = await Crypto.UnpackMessageAsync(wallet, message);
+            var unpacked = result.ToObject<UnpackResult>();
+            return unpacked.Message.ToObject<T>();
+        }
+    }
+
+    public class UnpackResult
+    {
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
+        [JsonProperty("sender_verkey")]
+        public string SenderVerkey { get; set; }
+
+        [JsonProperty("recipient_verkey")]
+        public string RecipientVerkey { get; set; }
+    }
+}

--- a/src/AgentFramework.Core/Utils/CryptoUtils.cs
+++ b/src/AgentFramework.Core/Utils/CryptoUtils.cs
@@ -16,7 +16,7 @@ namespace AgentFramework.Core.Utils
         /// <param name="recipientKey">The recipient key.</param>
         /// <param name="senderKey">The sender key.</param>
         /// <param name="message">The message.</param>
-        /// <returns></returns>
+        /// <returns>Encrypted message formatted as JWE using UTF8 byte order</returns>
         public static Task<byte[]> PackAsync(
             Wallet wallet, string recipientKey, string senderKey, byte[] message) =>
             PackAsync(wallet, new[] {recipientKey}, senderKey, message);
@@ -26,7 +26,7 @@ namespace AgentFramework.Core.Utils
         /// <param name="recipientKeys">The recipient keys.</param>
         /// <param name="senderKey">The sender key.</param>
         /// <param name="message">The message.</param>
-        /// <returns></returns>
+        /// <returns>Encrypted message formatted as JWE using UTF8 byte order</returns>
         public static Task<byte[]> PackAsync(
             Wallet wallet, string[] recipientKeys, string senderKey, byte[] message) =>
             Crypto.PackMessageAsync(wallet, recipientKeys.ToJson(), senderKey, message);
@@ -37,7 +37,7 @@ namespace AgentFramework.Core.Utils
         /// <param name="recipientKey">The recipient key.</param>
         /// <param name="senderKey">The sender key.</param>
         /// <param name="message">The message.</param>
-        /// <returns></returns>
+        /// <returns>Encrypted message formatted as JWE using UTF8 byte order</returns>
         public static Task<byte[]> PackAsync<T>(
             Wallet wallet, string recipientKey, string senderKey, T message) =>
             PackAsync(wallet, new[] {recipientKey}, senderKey, message.ToByteArray());
@@ -48,7 +48,7 @@ namespace AgentFramework.Core.Utils
         /// <param name="recipientKeys">The recipient keys.</param>
         /// <param name="senderKey">The sender key.</param>
         /// <param name="message">The message.</param>
-        /// <returns></returns>
+        /// <returns>Encrypted message formatted as JWE using UTF8 byte order</returns>
         public static Task<byte[]> PackAsync<T>(
             Wallet wallet, string[] recipientKeys, string senderKey, T message) =>
             Crypto.PackMessageAsync(wallet, recipientKeys.ToJson(), senderKey, message.ToByteArray());
@@ -56,7 +56,7 @@ namespace AgentFramework.Core.Utils
         /// <summary>Unpacks the asynchronous.</summary>
         /// <param name="wallet">The wallet.</param>
         /// <param name="message">The message.</param>
-        /// <returns></returns>
+        /// <returns>Decrypted message as UTF8 string and sender/recipient key information</returns>
         public static async Task<UnpackResult> UnpackAsync(Wallet wallet, byte[] message)
         {
             var result = await Crypto.UnpackMessageAsync(wallet, message);
@@ -67,7 +67,7 @@ namespace AgentFramework.Core.Utils
         /// <typeparam name="T"></typeparam>
         /// <param name="wallet">The wallet.</param>
         /// <param name="message">The message.</param>
-        /// <returns></returns>
+        /// <returns>Decrypted message as UTF8 string and sender/recipient key information</returns>
         public static async Task<T> UnpackAsync<T>(Wallet wallet, byte[] message)
         {
             var result = await Crypto.UnpackMessageAsync(wallet, message);
@@ -76,14 +76,23 @@ namespace AgentFramework.Core.Utils
         }
     }
 
-    public class UnpackResult
+    /// <summary>
+    /// Result object from <see cref="Crypto.UnpackMessageAsync"/>
+    /// </summary>
+    internal class UnpackResult
     {
+        /// <summary>Gets or sets the message encoded as UTF8 string.</summary>
+        /// <value>The message.</value>
         [JsonProperty("message")]
         public string Message { get; set; }
 
+        /// <summary>Gets or sets the sender verkey.</summary>
+        /// <value>The sender verkey.</value>
         [JsonProperty("sender_verkey")]
         public string SenderVerkey { get; set; }
 
+        /// <summary>Gets or sets the recipient verkey.</summary>
+        /// <value>The recipient verkey.</value>
         [JsonProperty("recipient_verkey")]
         public string RecipientVerkey { get; set; }
     }


### PR DESCRIPTION
Adds pack/unpack support. Unit tests are disabled since there's no docker image with 1.8 support yet, until libindy tags 1.8 as rc.
Can be run locally.

**Related to**: #72