### PR TITLE
Integration updates: schema details, unit test bug, serialization

### DIFF
--- a/src/AgentFramework.Core/Models/Records/CredentialRecord.cs
+++ b/src/AgentFramework.Core/Models/Records/CredentialRecord.cs
@@ -186,6 +186,7 @@ namespace AgentFramework.Core.Models.Records
     /// <summary>
     /// Enumeration of possible credential states
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CredentialState
     {
         /// <summary>

--- a/src/AgentFramework.Core/Models/Records/ProofRecord.cs
+++ b/src/AgentFramework.Core/Models/Records/ProofRecord.cs
@@ -106,6 +106,7 @@ namespace AgentFramework.Core.Models.Records
     /// <summary>
     /// Enumeration of possible proof states
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ProofState
     {
         /// <summary>

--- a/src/AgentFramework.Core/Models/Records/SchemaRecord.cs
+++ b/src/AgentFramework.Core/Models/Records/SchemaRecord.cs
@@ -11,14 +11,16 @@
         /// <returns>The type name.</returns>
         public override string TypeName => "AF.SchemaRecord";
 
-        /// <summary>
-        /// Gets or sets the schema content as a json string.
-        /// </summary>
-        /// <value>The schema as a json string.</value>
-        public string SchemaJson
-        {
-            get => Get();
-            set => Set(value);
-        }
+        /// <summary>Gets or sets the name.</summary>
+        /// <value>The name.</value>
+        public string Name { get; set; }
+
+        /// <summary>Gets or sets the version.</summary>
+        /// <value>The version.</value>
+        public string Version { get; set; }
+
+        /// <summary>Gets or sets the attribute names.</summary>
+        /// <value>The attribute names.</value>
+        public string[] AttributeNames { get; set; }
     }
 }

--- a/src/AgentFramework.Core/Runtime/DefaultSchemaService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultSchemaService.cs
@@ -52,7 +52,13 @@ namespace AgentFramework.Core.Runtime
         {
             var schema = await AnonCreds.IssuerCreateSchemaAsync(issuerDid, name, version, attributeNames.ToJson());
 
-            var schemaRecord = new SchemaRecord {Id = schema.SchemaId};
+            var schemaRecord = new SchemaRecord
+            {
+                Id = schema.SchemaId, 
+                Name = name, 
+                Version = version, 
+                AttributeNames = attributeNames
+            };
 
             await LedgerService.RegisterSchemaAsync(pool, wallet, issuerDid, schema.SchemaJson);
             await RecordService.AddAsync(wallet, schemaRecord);

--- a/test/AgentFramework.Core.Tests/Scenarios.cs
+++ b/test/AgentFramework.Core.Tests/Scenarios.cs
@@ -171,7 +171,7 @@ namespace AgentFramework.Core.Tests
             // Creata a schema and credential definition for this issuer
             var schemaId = await schemaService.CreateSchemaAsync(context.Pool, context.Wallet, issuerDid,
                 $"Test-Schema-{Guid.NewGuid().ToString()}", "1.0", attributeValues);
-            return (await schemaService.CreateCredentialDefinitionAsync(context.Pool, context.Wallet, schemaId, "Tag", issuerDid, false, 100, new Uri("http://mock/tails")), schemaId);
+            return (await schemaService.CreateCredentialDefinitionAsync(context.Pool, context.Wallet, schemaId,  issuerDid, "Tag", false, 100, new Uri("http://mock/tails")), schemaId);
         }
 
         private static T FindContentMessage<T>(IEnumerable<IAgentMessage> collection)


### PR DESCRIPTION
Some minor updates I discovered during integration phase. Having schema details in the record saves having to parse it manually. Not having the SchemaJson ensures it is always retrieved from the ledger.
Enum serialization updates to use String converter. Unit test bug with Tags.