### PR TITLE
Sample fixups.

### DIFF
--- a/samples/aspnetcore/Controllers/ConnectionsController.cs
+++ b/samples/aspnetcore/Controllers/ConnectionsController.cs
@@ -111,6 +111,11 @@ namespace WebAgent.Controllers
         [HttpPost]
         public IActionResult ViewInvitation(AcceptConnectionViewModel model)
         {
+            if (!ModelState.IsValid)
+            {
+                return Redirect(Request.Headers["Referer"].ToString());
+            }
+
             ViewData["InvitationDetails"] = model.InvitationDetails;
 
             string inviteRaw = null;

--- a/samples/aspnetcore/Protocols/TrustPing/TrustPingResponseMessage.cs
+++ b/samples/aspnetcore/Protocols/TrustPing/TrustPingResponseMessage.cs
@@ -21,6 +21,7 @@ namespace WebAgent.Messages
         /// <value>
         /// The comment.
         /// </value>
+        [JsonProperty("comment")]
         public string Comment { get; set; }
     }
 }

--- a/samples/aspnetcore/Startup.cs
+++ b/samples/aspnetcore/Startup.cs
@@ -53,10 +53,12 @@ namespace WebAgent
             
             // Add agent middleware
             var agentBaseUrl = Environment.GetEnvironmentVariable("ENDPOINT_HOST") ?? Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+            var agentName = Environment.GetEnvironmentVariable("AGENT_NAME") ?? NameGenerator.GetRandomName();
+
             app.UseAgentFramework<WebAgentMiddleware>($"{new Uri(new Uri(agentBaseUrl), "/agent")}",
                 obj =>
                 {
-                    obj.AddOwnershipInfo(NameGenerator.GetRandomName(), null);
+                    obj.AddOwnershipInfo(agentName, null);
                 });
 
             // fun identicons

--- a/src/AgentFramework.Core/Messages/Connections/ConnectionResponseMessage.cs
+++ b/src/AgentFramework.Core/Messages/Connections/ConnectionResponseMessage.cs
@@ -23,15 +23,6 @@ namespace AgentFramework.Core.Messages.Connections
         /// <value>
         /// The connection object.
         /// </value>
-        [JsonProperty("connection")]
-        public Connection Connection { get; set; }
-
-        /// <summary>
-        /// Gets or sets the connection object.
-        /// </summary>
-        /// <value>
-        /// The connection object.
-        /// </value>
         [JsonProperty("connection~sig")]
         public SignatureDecorator ConnectionSig { get; set; }
 
@@ -39,7 +30,6 @@ namespace AgentFramework.Core.Messages.Connections
         public override string ToString() =>
             $"{GetType().Name}: " +
             $"Id={Id}, " +
-            $"Type={Type}, " +
-            $"Did={Connection?.Did}, ";
+            $"Type={Type}, ";
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Several minor tweaks to the sample web agent. 

#### Changes proposed in this pull request:

- Connection field from the connection response is gone so only "connection~sig" is present,
- Traps and handles clicking "View Invitation" when no invite is supplied
- Comment field on the ping response when serialized to json is correctly represented lower case.
- Optional environment variable "AGENT_NAME" can be supplied to populate the agents name.

**Fixes**: #113 #112 