### PR TITLE
Introduce PoolAwaitable for lazy pool initialization

### DIFF
--- a/src/AgentFramework.Core/Contracts/IAgentContext.cs
+++ b/src/AgentFramework.Core/Contracts/IAgentContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using AgentFramework.Core.Models;
 using AgentFramework.Core.Models.Records;
 using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.WalletApi;
@@ -16,7 +17,7 @@ namespace AgentFramework.Core.Contracts
 
         /// <summary>Gets or sets the pool.</summary>
         /// <value>The pool.</value>
-        Pool Pool { get; set; }
+        PoolAwaitable Pool { get; set; }
 
         /// <summary>Name/value utility store to pass data
         /// along the execution pipeline.</summary>

--- a/src/AgentFramework.Core/Models/DefaultAgentContext.cs
+++ b/src/AgentFramework.Core/Models/DefaultAgentContext.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Models.Records;
-using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.WalletApi;
 
 namespace AgentFramework.Core.Models
@@ -24,7 +23,7 @@ namespace AgentFramework.Core.Models
         /// <summary>
         /// The agent context pool.
         /// </summary>
-        public Pool Pool { get; set; }
+        public PoolAwaitable Pool { get; set; }
 
         /// <inheritdoc />
         /// <summary>

--- a/src/AgentFramework.Core/Models/PoolAwaitable.cs
+++ b/src/AgentFramework.Core/Models/PoolAwaitable.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Hyperledger.Indy.PoolApi;
+
+namespace AgentFramework.Core.Models
+{
+    /// <summary>
+    /// Awaitable pool handle.
+    /// </summary>
+    public struct PoolAwaitable
+    {
+        private readonly Func<Task<Pool>> _initializer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PoolAwaitable"/> struct.
+        /// </summary>
+        /// <param name="initializer">Initializer.</param>
+        public PoolAwaitable(Func<Task<Pool>> initializer)
+        {
+            _initializer = initializer;
+        }
+
+        /// <summary>
+        /// Gets the awaiter for this instance.
+        /// </summary>
+        /// <returns>The awaiter.</returns>
+        public TaskAwaiter<Pool> GetAwaiter()
+        {
+            return _initializer().GetAwaiter();
+        }
+
+        /// <summary>
+        /// Create new <see cref="PoolAwaitable"/> instance from existing <see cref="Pool"/> handle
+        /// </summary>
+        /// <returns>The pool awatable.</returns>
+        /// <param name="pool">Pool.</param>
+        public static PoolAwaitable FromPool(Pool pool)
+        {
+            return new PoolAwaitable(() => Task.FromResult(pool));
+        }
+    }
+}

--- a/src/AgentFramework.Core/Runtime/DefaultAgentContextProvider.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultAgentContextProvider.cs
@@ -42,7 +42,8 @@ namespace AgentFramework.Core.Runtime
             {
                 Wallet = await _walletService.GetWalletAsync(_walletOptions.WalletConfiguration,
                     _walletOptions.WalletCredentials),
-                Pool = await _poolService.GetPoolAsync(_poolOptions.PoolName, _poolOptions.ProtocolVersion)
+                Pool = new PoolAwaitable(() => _poolService.GetPoolAsync(
+                    _poolOptions.PoolName, _poolOptions.ProtocolVersion))
             };
         }
     }

--- a/src/AgentFramework.Core/Runtime/DefaultCredentialService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultCredentialService.cs
@@ -146,8 +146,8 @@ namespace AgentFramework.Core.Runtime
                     $"Credential state was invalid. Expected '{CredentialState.Offered}', found '{credential.State}'");
 
             var connection = await ConnectionService.GetAsync(agentContext, credential.ConnectionId);
-            
-            var definition = await LedgerService.LookupDefinitionAsync(agentContext.Pool, credential.CredentialDefinitionId);
+
+            var definition = await LedgerService.LookupDefinitionAsync(await agentContext.Pool, credential.CredentialDefinitionId);
             var provisioning = await ProvisioningService.GetProvisioningAsync(agentContext.Wallet);
             
             var request = await AnonCreds.ProverCreateCredentialReqAsync(agentContext.Wallet, connection.MyDid, credential.OfferJson,
@@ -197,14 +197,14 @@ namespace AgentFramework.Core.Runtime
                 throw new AgentFrameworkException(ErrorCode.RecordInInvalidState,
                     $"Credential state was invalid. Expected '{CredentialState.Requested}', found '{credentialRecord.State}'");
 
-            var credentialDefinition = await LedgerService.LookupDefinitionAsync(agentContext.Pool, definitionId);
+            var credentialDefinition = await LedgerService.LookupDefinitionAsync(await agentContext.Pool, definitionId);
 
             string revocationRegistryDefinitionJson = null;
             if (!string.IsNullOrEmpty(revRegId))
             {
                 // If credential supports revocation, lookup registry definition
                 var revocationRegistry =
-                    await LedgerService.LookupRevocationRegistryDefinitionAsync(agentContext.Pool, revRegId);
+                    await LedgerService.LookupRevocationRegistryDefinitionAsync(await agentContext.Pool, revRegId);
                 revocationRegistryDefinitionJson = revocationRegistry.ObjectJson;
             }
 
@@ -380,7 +380,7 @@ namespace AgentFramework.Core.Runtime
 
             if (definitionRecord.SupportsRevocation)
             {
-                await LedgerService.SendRevocationRegistryEntryAsync(agentContext.Wallet, agentContext.Pool, issuerDid,
+                await LedgerService.SendRevocationRegistryEntryAsync(agentContext.Wallet, await agentContext.Pool, issuerDid,
                     revocationRegistryId,
                     "CL_ACCUM", issuedCredential.RevocRegDeltaJson);
                 credential.CredentialRevocationId = issuedCredential.RevocId;
@@ -425,7 +425,7 @@ namespace AgentFramework.Core.Runtime
                 revocationRecord.Id, credential.CredentialRevocationId);
 
             // Write the delta state on the ledger for the corresponding revocation registry
-            await LedgerService.SendRevocationRegistryEntryAsync(agentContext.Wallet, agentContext.Pool, issuerDid,
+            await LedgerService.SendRevocationRegistryEntryAsync(agentContext.Wallet, await agentContext.Pool, issuerDid,
                 revocationRecord.Id,
                 "CL_ACCUM", revocRegistryDeltaJson);
 

--- a/src/AgentFramework.Core/Runtime/DefaultEphemeralChallengeService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultEphemeralChallengeService.cs
@@ -151,7 +151,7 @@ namespace AgentFramework.Core.Runtime
                 {
                     Name = config.Name,
                     Version = "1.0",
-                    Nonce = Guid.NewGuid().ToString("N"),
+                    Nonce = $"0{Guid.NewGuid().ToString("N")}",
                     RequestedAttributes = proofRequestConfig.RequestedAttributes,
                     RequestedPredicates = proofRequestConfig.RequestedPredicates,
                     NonRevoked = proofRequestConfig.NonRevoked

--- a/src/AgentFramework.Core/Runtime/DefaultProofService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultProofService.cs
@@ -207,17 +207,17 @@ namespace AgentFramework.Core.Runtime
                         await AnonCreds.ProverGetCredentialAsync(agentContext.Wallet, credId)));
             }
 
-            var schemas = await BuildSchemasAsync(agentContext.Pool,
+            var schemas = await BuildSchemasAsync(await agentContext.Pool,
                 credentialObjects
                     .Select(x => x.SchemaId)
                     .Distinct());
 
-            var definitions = await BuildCredentialDefinitionsAsync(agentContext.Pool,
+            var definitions = await BuildCredentialDefinitionsAsync(await agentContext.Pool,
                 credentialObjects
                     .Select(x => x.CredentialDefinitionId)
                     .Distinct());
 
-            var revocationStates = await BuildRevocationStatesAsync(agentContext.Pool,
+            var revocationStates = await BuildRevocationStatesAsync(await agentContext.Pool,
                 credentialObjects,
                 requestedCredentials);
 
@@ -256,17 +256,17 @@ namespace AgentFramework.Core.Runtime
                         await AnonCreds.ProverGetCredentialAsync(agentContext.Wallet, credId)));
             }
 
-            var schemas = await BuildSchemasAsync(agentContext.Pool,
+            var schemas = await BuildSchemasAsync(await agentContext.Pool,
                 credentialObjects
                     .Select(x => x.SchemaId)
                     .Distinct());
 
-            var definitions = await BuildCredentialDefinitionsAsync(agentContext.Pool,
+            var definitions = await BuildCredentialDefinitionsAsync(await agentContext.Pool,
                 credentialObjects
                     .Select(x => x.CredentialDefinitionId)
                     .Distinct());
 
-            var revocationStates = await BuildRevocationStatesAsync(agentContext.Pool,
+            var revocationStates = await BuildRevocationStatesAsync(await agentContext.Pool,
                 credentialObjects,
                 requestedCredentials);
 
@@ -314,25 +314,25 @@ namespace AgentFramework.Core.Runtime
         {
             var proof = JsonConvert.DeserializeObject<PartialProof>(proofJson);
 
-            var schemas = await BuildSchemasAsync(agentContext.Pool,
+            var schemas = await BuildSchemasAsync(await agentContext.Pool,
                 proof.Identifiers
                     .Select(x => x.SchemaId)
                     .Where(x => x != null)
                     .Distinct());
 
-            var definitions = await BuildCredentialDefinitionsAsync(agentContext.Pool,
+            var definitions = await BuildCredentialDefinitionsAsync(await agentContext.Pool,
                 proof.Identifiers
                     .Select(x => x.CredentialDefintionId)
                     .Where(x => x != null)
                     .Distinct());
 
-            var revocationDefinitions = await BuildRevocationRegistryDefinitionsAsync(agentContext.Pool,
+            var revocationDefinitions = await BuildRevocationRegistryDefinitionsAsync(await agentContext.Pool,
                 proof.Identifiers
                     .Select(x => x.RevocationRegistryId)
                     .Where(x => x != null)
                     .Distinct());
 
-            var revocationRegistries = await BuildRevocationRegistryDetlasAsync(agentContext.Pool,
+            var revocationRegistries = await BuildRevocationRegistryDetlasAsync(await agentContext.Pool,
                 proof.Identifiers
                     .Where(x => x.RevocationRegistryId != null));
 

--- a/test/AgentFramework.Core.Tests/CredentialTests.cs
+++ b/test/AgentFramework.Core.Tests/CredentialTests.cs
@@ -127,12 +127,12 @@ namespace AgentFramework.Core.Tests
             _issuerWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(_issuerConfig, Credentials), 
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
             _holderWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(_holderConfig, Credentials), 
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
         }
 

--- a/test/AgentFramework.Core.Tests/EphemeralChallengeTests.cs
+++ b/test/AgentFramework.Core.Tests/EphemeralChallengeTests.cs
@@ -147,17 +147,17 @@ namespace AgentFramework.Core.Tests
             _issuerWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(_issuerConfig, Credentials), 
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
             _holderWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(_holderConfig, Credentials), 
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
             _requestorWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(_requestorConfig, Credentials),
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
         }
 

--- a/test/AgentFramework.Core.Tests/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/ProofTests.cs
@@ -198,7 +198,7 @@ namespace AgentFramework.Core.Tests
                 {
                     Name = "ProofReq",
                     Version = "1.0",
-                    Nonce = "123",
+                    Nonce = $"0{Guid.NewGuid().ToString("N")}",
                     RequestedAttributes = new Dictionary<string, ProofAttributeInfo>
                     {
                         {"first-name-requirement", new ProofAttributeInfo {Name = "first_name"}}

--- a/test/AgentFramework.Core.Tests/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/ProofTests.cs
@@ -150,17 +150,17 @@ namespace AgentFramework.Core.Tests
             _issuerWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(IssuerConfig, WalletCredentials),
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
             _holderWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(HolderConfig, WalletCredentials),
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
             _requestorWallet = new AgentContext
             {
                 Wallet = await Wallet.OpenWalletAsync(RequestorConfig, WalletCredentials),
-                Pool = _pool
+                Pool = PoolAwaitable.FromPool(_pool)
             };
 
 

--- a/test/AgentFramework.Core.Tests/Scenarios.cs
+++ b/test/AgentFramework.Core.Tests/Scenarios.cs
@@ -172,9 +172,9 @@ namespace AgentFramework.Core.Tests
         internal static async Task<(string,string)> CreateDummySchemaAndNonRevokableCredDef(IAgentContext context, ISchemaService schemaService, string issuerDid, string[] attributeValues)
         {
             // Create a schema and credential definition for this issuer
-            var schemaId = await schemaService.CreateSchemaAsync(context.Pool, context.Wallet, issuerDid,
+            var schemaId = await schemaService.CreateSchemaAsync(await context.Pool, context.Wallet, issuerDid,
                 $"Test-Schema-{Guid.NewGuid().ToString()}", "1.0", attributeValues);
-            return (await schemaService.CreateCredentialDefinitionAsync(context.Pool, context.Wallet, schemaId,  issuerDid, "Tag", false, 100, new Uri("http://mock/tails")), schemaId);
+            return (await schemaService.CreateCredentialDefinitionAsync(await context.Pool, context.Wallet, schemaId,  issuerDid, "Tag", false, 100, new Uri("http://mock/tails")), schemaId);
         }
 
         private static T FindContentMessage<T>(IEnumerable<AgentMessage> collection)


### PR DESCRIPTION
Just a concept I came up with. The goal is to make Pool handle have lazy initialization. There's no need to make a connection to the pool nodes until that connection is actually required.
This also makes it possible to run an agent that doesn't require a node configured, for example for making connections only, or facilitating routing, etc.
The samples project can't use the new DefaultAgentContext without making connection to a running node because of this.