### PR TITLE
Minor fix to proof message with un-needed json attribute

### DIFF
--- a/src/AgentFramework.Core/Messages/Proofs/ProofMessage.cs
+++ b/src/AgentFramework.Core/Messages/Proofs/ProofMessage.cs
@@ -6,7 +6,6 @@ namespace AgentFramework.Core.Messages.Proofs
     /// <summary>
     /// A proof content message.
     /// </summary>
-    [JsonConverter(typeof(AgentMessageReader<ProofMessage>))]
     public class ProofMessage : AgentMessage
     {
         /// <inheritdoc />


### PR DESCRIPTION
#### Short description of what this resolves:

Message decorators were being dropped from this particular message due to the presence of this class attribute.