### PR TITLE
Wallet Concurrency 

### DIFF
--- a/test/AgentFramework.Core.Tests/WalletTests.cs
+++ b/test/AgentFramework.Core.Tests/WalletTests.cs
@@ -10,6 +10,29 @@ namespace AgentFramework.Core.Tests
     public class WalletTests
     {
         [Fact]
+        public async Task ConcurrentWalletAccess()
+        {
+            var walletService = new DefaultWalletService();
+
+            var config = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
+            var creds = new WalletCredentials { Key = "1" };
+
+            await walletService.CreateWalletAsync(config, creds);
+
+            Task<Wallet> openWalletTask1 = walletService.GetWalletAsync(config, creds);
+            Task<Wallet> openWalletTask2 = walletService.GetWalletAsync(config, creds);
+            Task<Wallet> openWalletTask3 = walletService.GetWalletAsync(config, creds);
+            Task<Wallet> openWalletTask4 = walletService.GetWalletAsync(config, creds);
+
+            await Task.WhenAll(openWalletTask1, openWalletTask2, openWalletTask3, openWalletTask4);
+
+            Assert.True(openWalletTask1.Result.IsOpen);
+            Assert.True(openWalletTask2.Result.IsOpen);
+            Assert.True(openWalletTask3.Result.IsOpen);
+            Assert.True(openWalletTask4.Result.IsOpen);
+        }
+
+        [Fact]
         public async Task ProvisionNewWallet()
         {
             var walletService = new DefaultWalletService();


### PR DESCRIPTION
#### Short description of what this resolves:

If two requests are made simultaneously to access the same wallet, when it is not open previously, the lagging call will fail with a `WalletAlreadyOpenedException`, this minor tweak fixes that case and adds a test case.