### PR TITLE
Added null checks to relivant .ToString overrides

### DIFF
--- a/src/AgentFramework.Core/Messages/Connections/ConnectionInvitationMessage.cs
+++ b/src/AgentFramework.Core/Messages/Connections/ConnectionInvitationMessage.cs
@@ -68,6 +68,6 @@ namespace AgentFramework.Core.Messages.Connections
             $"Type={Type}, " +
             $"Name={Label}, " +
             $"ImageUrl={ImageUrl}, " +
-            $"RoutingKeys={string.Join(",", RoutingKeys)}, ";
+            $"RoutingKeys={string.Join(",", RoutingKeys ?? new string[0])}, ";
     }
 }

--- a/src/AgentFramework.Core/Models/Connections/InviteConfiguration.cs
+++ b/src/AgentFramework.Core/Models/Connections/InviteConfiguration.cs
@@ -50,6 +50,6 @@ namespace AgentFramework.Core.Models.Connections
             $"TheirAlias={TheirAlias}, " +
             $"MyAlias={MyAlias}, " +
             $"AutoAcceptConnection={AutoAcceptConnection}, " +
-            $"Tags={string.Join(",", Tags)}";
+            $"Tags={string.Join(",", Tags ?? new Dictionary<string, string>())}";
     }
 }

--- a/src/AgentFramework.Core/Models/Credentials/CredentialInfo.cs
+++ b/src/AgentFramework.Core/Models/Credentials/CredentialInfo.cs
@@ -70,6 +70,6 @@ namespace AgentFramework.Core.Models.Credentials
             $"CredentialDefinitionId={CredentialDefinitionId}, " +
             $"RevocationRegistryId={RevocationRegistryId}, " +
             $"CredentialRevocationId={CredentialRevocationId}, " +
-            $"Attributes={string.Join(",", Attributes ?? new string[0])}";
+            $"Attributes={string.Join(",", Attributes ?? new Dictionary<string,string>())}";
     }
 }

--- a/src/AgentFramework.Core/Models/Credentials/CredentialInfo.cs
+++ b/src/AgentFramework.Core/Models/Credentials/CredentialInfo.cs
@@ -70,6 +70,6 @@ namespace AgentFramework.Core.Models.Credentials
             $"CredentialDefinitionId={CredentialDefinitionId}, " +
             $"RevocationRegistryId={RevocationRegistryId}, " +
             $"CredentialRevocationId={CredentialRevocationId}, " +
-            $"Attributes={string.Join(",", Attributes)}";
+            $"Attributes={string.Join(",", Attributes ?? new string[0])}";
     }
 }

--- a/src/AgentFramework.Core/Models/Credentials/OfferConfiguration.cs
+++ b/src/AgentFramework.Core/Models/Credentials/OfferConfiguration.cs
@@ -36,7 +36,7 @@ namespace AgentFramework.Core.Models.Credentials
             $"{GetType().Name}: " +
             $"CredentialDefinitionId={CredentialDefinitionId}, " +
             $"IssuerDid={IssuerDid}, " +
-            $"CredentialAttributeValues={string.Join(",", CredentialAttributeValues)}, " +
+            $"CredentialAttributeValues={string.Join(",", CredentialAttributeValues ?? new List<CredentialPreviewAttribute>())}, " +
             $"Tags={string.Join(",", Tags)}";
     }
 }

--- a/src/AgentFramework.Core/Models/Proofs/PartialProof.cs
+++ b/src/AgentFramework.Core/Models/Proofs/PartialProof.cs
@@ -29,7 +29,7 @@ namespace AgentFramework.Core.Models.Proofs
         /// <inheritdoc />
         public override string ToString() =>
             $"{GetType().Name}: " +
-            $"Identifiers={string.Join(",", Identifiers)}, " +
+            $"Identifiers={string.Join(",", Identifiers ?? new List<ProofIdentifier>())}, " +
             $"RequestedProof={RequestedProof}";
     }
 
@@ -109,8 +109,8 @@ namespace AgentFramework.Core.Models.Proofs
         /// <inheritdoc />
         public override string ToString() =>
             $"{GetType().Name}: " +
-            $"RevealedAttributes={string.Join(",", RevealedAttributes)}, " +
-            $"SelfAttestedAttributes={string.Join(",", SelfAttestedAttributes)}";
+            $"RevealedAttributes={string.Join(",", RevealedAttributes ?? new Dictionary<string, ProofAttribute>())}, " +
+            $"SelfAttestedAttributes={string.Join(",", SelfAttestedAttributes ?? new Dictionary<string, ProofAttribute>())}";
     }
 
     /// <summary>

--- a/src/AgentFramework.Core/Models/Proofs/ProofAttributeInfo.cs
+++ b/src/AgentFramework.Core/Models/Proofs/ProofAttributeInfo.cs
@@ -76,7 +76,7 @@ namespace AgentFramework.Core.Models.Proofs
         public override string ToString() =>
             $"{GetType().Name}: " +
             $"Name={Name}, " +
-            $"Restrictions={string.Join(",", Restrictions)}, " +
+            $"Restrictions={string.Join(",", Restrictions ?? new List<AttributeFilter>())}, " +
             $"NonRevoked={NonRevoked}";
     }
 }

--- a/src/AgentFramework.Core/Models/Proofs/ProofRequest.cs
+++ b/src/AgentFramework.Core/Models/Proofs/ProofRequest.cs
@@ -57,8 +57,8 @@ namespace AgentFramework.Core.Models.Proofs
             $"Name={Name}, " +
             $"Version={Version}, " +
             $"Nonce={Nonce}, " +
-            $"RequestedAttributes={string.Join(",", RequestedAttributes)}, " +
-            $"RequestedPredicates={string.Join(",", RequestedPredicates)}, " +
+            $"RequestedAttributes={string.Join(",", RequestedAttributes ?? new Dictionary<string, ProofAttributeInfo>())}, " +
+            $"RequestedPredicates={string.Join(",", RequestedPredicates ?? new Dictionary<string, ProofPredicateInfo>())}, " +
             $"NonRevoked={NonRevoked}";
     }
 }

--- a/src/AgentFramework.Core/Models/Proofs/ProofRequestConfiguration.cs
+++ b/src/AgentFramework.Core/Models/Proofs/ProofRequestConfiguration.cs
@@ -33,8 +33,8 @@ namespace AgentFramework.Core.Models.Proofs
         /// <inheritdoc />
         public override string ToString() =>
             $"{GetType().Name}: " +
-            $"RequestedAttributes={string.Join(",", RequestedAttributes)}, " +
-            $"RequestedPredicates={string.Join(",", RequestedPredicates)}, " +
+            $"RequestedAttributes={string.Join(",", RequestedAttributes ?? new Dictionary<string, ProofAttributeInfo>())}, " +
+            $"RequestedPredicates={string.Join(",", RequestedPredicates ?? new Dictionary<string, ProofPredicateInfo>())}, " +
             $"NonRevoked={NonRevoked}";
     }
 }

--- a/src/AgentFramework.Core/Models/Proofs/RequestedCredentials.cs
+++ b/src/AgentFramework.Core/Models/Proofs/RequestedCredentials.cs
@@ -49,9 +49,9 @@ namespace AgentFramework.Core.Models.Proofs
         /// <inheritdoc />
         public override string ToString() =>
             $"{GetType().Name}: " +
-            $"RequestedAttributes={string.Join(",", RequestedAttributes)}, " +
-            $"SelfAttestedAttributes={string.Join(",", SelfAttestedAttributes)}, " +
-            $"RequestedPredicates={string.Join(",", RequestedPredicates)}, " +
+            $"RequestedAttributes={string.Join(",", RequestedAttributes ?? new Dictionary<string, RequestedAttribute>())}, " +
+            $"SelfAttestedAttributes={string.Join(",", SelfAttestedAttributes ?? new Dictionary<string, string>())}, " +
+            $"RequestedPredicates={string.Join(",", RequestedPredicates ?? new Dictionary<string, RequestedAttribute>())}, " +
             $"CredentialIdentifiers={string.Join(",", GetCredentialIdentifiers())}";
     }
 }

--- a/src/AgentFramework.Core/Models/Records/SchemaRecord.cs
+++ b/src/AgentFramework.Core/Models/Records/SchemaRecord.cs
@@ -28,7 +28,7 @@
             $"{GetType().Name}: " +
             $"Name={Name}, " +
             $"Version={Version}, " +
-            $"AttributeNames={string.Join(",", AttributeNames)}, " +
+            $"AttributeNames={string.Join(",", AttributeNames ?? new string[0])}, " +
             base.ToString();
     }
 }

--- a/src/AgentFramework.Core/Models/Records/Search/SearchItem.cs
+++ b/src/AgentFramework.Core/Models/Records/Search/SearchItem.cs
@@ -42,6 +42,6 @@ namespace AgentFramework.Core.Models.Records.Search
             $"Id={Id}, " +
             $"Type={Type}, " +
             $"Value={Value}, " +
-            $"Tags={string.Join(",", Tags)}";
+            $"Tags={string.Join(",", Tags ?? new Dictionary<string, string>())}";
     }
 }

--- a/src/AgentFramework.Core/Models/Records/Search/SearchResult.cs
+++ b/src/AgentFramework.Core/Models/Records/Search/SearchResult.cs
@@ -18,6 +18,6 @@ namespace AgentFramework.Core.Models.Records.Search
         /// <inheritdoc />
         public override string ToString() =>
             $"{GetType().Name}: " +
-            $"Records={string.Join(",", Records)}";
+            $"Records={string.Join(",", Records ?? new List<SearchItem>())}";
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

The .ToString() overrides were not null safe in all areas, namely because of the usage of string.Join() this PR adds checks in the relevant places.