### PR TITLE
Return routing support

### DIFF
--- a/scripts/start-node-pool.ps1
+++ b/scripts/start-node-pool.ps1
@@ -1,0 +1,3 @@
+docker container rm indy_pool
+docker build -f docker/indy-pool.dockerfile -t indy_pool .
+docker run --name indy_pool -itd -p 9701-9709:9701-9709 indy_pool 

--- a/scripts/start-node-pool.ps1
+++ b/scripts/start-node-pool.ps1
@@ -1,3 +1,0 @@
-docker container rm indy_pool
-docker build -f docker/indy-pool.dockerfile -t indy_pool .
-docker run --name indy_pool -itd -p 9701-9709:9701-9709 indy_pool 

--- a/scripts/stop-node-pool.ps1
+++ b/scripts/stop-node-pool.ps1
@@ -1,0 +1,1 @@
+docker stop indy_pool

--- a/scripts/stop-node-pool.ps1
+++ b/scripts/stop-node-pool.ps1
@@ -1,1 +1,0 @@
-docker stop indy_pool

--- a/src/AgentFramework.AspNetCore/Middleware/AgentMiddleware.cs
+++ b/src/AgentFramework.AspNetCore/Middleware/AgentMiddleware.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Extensions;
 using AgentFramework.Core.Handlers;
+using AgentFramework.Core.Runtime;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -54,7 +55,10 @@ namespace AgentFramework.AspNetCore.Middleware
                 context.Response.StatusCode = 200;
 
                 if (result != null)
+                {
+                    context.Response.ContentType = DefaultMessageService.AgentWireMessageMimeType;
                     await context.Response.Body.WriteAsync(result, 0, result.Length);
+                }
                 else
                     await context.Response.WriteAsync(string.Empty);
             }

--- a/src/AgentFramework.Core.Handlers/AgentContext.cs
+++ b/src/AgentFramework.Core.Handlers/AgentContext.cs
@@ -9,14 +9,14 @@ namespace AgentFramework.Core.Handlers
     /// </summary>
     public class AgentContext : DefaultAgentContext
     {
-        private readonly ConcurrentQueue<MessagePayload> _queue = new ConcurrentQueue<MessagePayload>();
+        private readonly ConcurrentQueue<MessageContext> _queue = new ConcurrentQueue<MessageContext>();
         
         /// <summary>
         /// Adds a message to the current processing queue
         /// </summary>
         /// <param name="message"></param>
-        public void AddNext(MessagePayload message) => _queue.Enqueue(message);
+        public void AddNext(MessageContext message) => _queue.Enqueue(message);
 
-        internal bool TryGetNext(out MessagePayload message) => _queue.TryDequeue(out message);
+        internal bool TryGetNext(out MessageContext message) => _queue.TryDequeue(out message);
     }
 }

--- a/src/AgentFramework.Core.Handlers/Extensions.cs
+++ b/src/AgentFramework.Core.Handlers/Extensions.cs
@@ -12,8 +12,8 @@ namespace AgentFramework.Core.Handlers
         /// <summary>Wraps the message in payload.</summary>
         /// <param name="agentMessage">The agent message.</param>
         /// <returns></returns>
-        public static MessagePayload AsMessagePayload(this AgentMessage agentMessage) =>
-            new MessagePayload(agentMessage);
+        public static MessageContext AsMessagePayload(this AgentMessage agentMessage) =>
+            new MessageContext(agentMessage);
 
         /// <summary>Adds the default message handlers.</summary>
         /// <param name="collection">The collection.</param>
@@ -32,7 +32,6 @@ namespace AgentFramework.Core.Handlers
             {
                 Wallet = context.Wallet,
                 Pool = context.Pool,
-                Connection = context.Connection,
                 State = context.State
             };
         }

--- a/src/AgentFramework.Core.Handlers/Extensions.cs
+++ b/src/AgentFramework.Core.Handlers/Extensions.cs
@@ -12,7 +12,7 @@ namespace AgentFramework.Core.Handlers
         /// <summary>Wraps the message in payload.</summary>
         /// <param name="agentMessage">The agent message.</param>
         /// <returns></returns>
-        public static MessageContext AsMessagePayload(this AgentMessage agentMessage) =>
+        public static MessageContext AsMessageContext(this AgentMessage agentMessage) =>
             new MessageContext(agentMessage);
 
         /// <summary>Adds the default message handlers.</summary>

--- a/src/AgentFramework.Core.Handlers/IMessageHandler.cs
+++ b/src/AgentFramework.Core.Handlers/IMessageHandler.cs
@@ -24,6 +24,6 @@ namespace AgentFramework.Core.Handlers
         /// <param name="agentContext">The agent context.</param>
         /// <param name="messagePayload">The agent message context.</param>
         /// <returns>Outgoing message context async.</returns>
-        Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessagePayload messagePayload);
+        Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload);
     }
 }

--- a/src/AgentFramework.Core.Handlers/IMessageHandler.cs
+++ b/src/AgentFramework.Core.Handlers/IMessageHandler.cs
@@ -22,8 +22,8 @@ namespace AgentFramework.Core.Handlers
         /// Processes the agent message
         /// </summary>
         /// <param name="agentContext">The agent context.</param>
-        /// <param name="messagePayload">The agent message context.</param>
+        /// <param name="messageContext">The agent message context.</param>
         /// <returns>Outgoing message context async.</returns>
-        Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload);
+        Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext);
     }
 }

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultConnectionHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultConnectionHandler.cs
@@ -42,24 +42,24 @@ namespace AgentFramework.Core.Handlers.Internal
         /// Processes the agent message
         /// </summary>
         /// <param name="agentContext"></param>
-        /// <param name="messagePayload">The agent message agentContext.</param>
+        /// <param name="messageContext">The agent message agentContext.</param>
         /// <returns></returns>
         /// <exception cref="AgentFrameworkException">Unsupported message type {message.Type}</exception>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext)
         {
-            switch (messagePayload.GetMessageType())
+            switch (messageContext.GetMessageType())
             {
                 case MessageTypes.ConnectionInvitation:
-                    var invitation = messagePayload.GetMessageAs<ConnectionInvitationMessage>();
+                    var invitation = messageContext.GetMessage<ConnectionInvitationMessage>();
                     await _connectionService.CreateRequestAsync(agentContext, invitation);
                     return null;
 
                 case MessageTypes.ConnectionRequest:
                 {
-                    var request = messagePayload.GetMessageAs<ConnectionRequestMessage>();
-                    var connectionId = await _connectionService.ProcessRequestAsync(agentContext, request, messagePayload.Connection);
+                    var request = messageContext.GetMessage<ConnectionRequestMessage>();
+                    var connectionId = await _connectionService.ProcessRequestAsync(agentContext, request, messageContext.Connection);
                     // Auto accept connection if set during invitation
-                    if (messagePayload.Connection.GetTag(TagConstants.AutoAcceptConnection) == "true")
+                    if (messageContext.Connection.GetTag(TagConstants.AutoAcceptConnection) == "true")
                     {
                         (var message, var _) = await _connectionService.CreateResponseAsync(agentContext, connectionId);
                         return message;
@@ -69,13 +69,13 @@ namespace AgentFramework.Core.Handlers.Internal
 
                 case MessageTypes.ConnectionResponse:
                 {
-                    var response = messagePayload.GetMessageAs<ConnectionResponseMessage>();
-                    await _connectionService.ProcessResponseAsync(agentContext, response, messagePayload.Connection);
+                    var response = messageContext.GetMessage<ConnectionResponseMessage>();
+                    await _connectionService.ProcessResponseAsync(agentContext, response, messageContext.Connection);
                     return null;
                 }
                 default:
                     throw new AgentFrameworkException(ErrorCode.InvalidMessage,
-                        $"Unsupported message type {messagePayload.GetMessageType()}");
+                        $"Unsupported message type {messageContext.GetMessageType()}");
             }
         }
     }

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultCredentialHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultCredentialHandler.cs
@@ -43,33 +43,33 @@ namespace AgentFramework.Core.Handlers.Internal
         /// <param name="messagePayload">The agent message.</param>
         /// <returns></returns>
         /// <exception cref="AgentFrameworkException">Unsupported message type {messageType}</exception>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessagePayload messagePayload)
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
         {
             switch (messagePayload.GetMessageType())
             {
                 case MessageTypes.CredentialOffer:
                 {
-                    var offer = messagePayload.GetMessage<CredentialOfferMessage>();
+                    var offer = messagePayload.GetMessageAs<CredentialOfferMessage>();
                     await _credentialService.ProcessOfferAsync(
-                        agentContext, offer, agentContext.Connection);
+                        agentContext, offer, messagePayload.Connection);
 
                     return null;
                 }
 
                 case MessageTypes.CredentialRequest:
                 {
-                    var request = messagePayload.GetMessage<CredentialRequestMessage>();
+                    var request = messagePayload.GetMessageAs<CredentialRequestMessage>();
                     await _credentialService.ProcessCredentialRequestAsync(
-                        agentContext, request, agentContext.Connection);
+                        agentContext, request, messagePayload.Connection);
 
                     return null;
                 }
 
                 case MessageTypes.Credential:
                 {
-                    var credential = messagePayload.GetMessage<CredentialMessage>();
+                    var credential = messagePayload.GetMessageAs<CredentialMessage>();
                     await _credentialService.ProcessCredentialAsync(
-                        agentContext, credential, agentContext.Connection);
+                        agentContext, credential, messagePayload.Connection);
 
                     return null;
                 }

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultCredentialHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultCredentialHandler.cs
@@ -40,42 +40,42 @@ namespace AgentFramework.Core.Handlers.Internal
         /// Processes the agent message
         /// </summary>
         /// <param name="agentContext"></param>
-        /// <param name="messagePayload">The agent message.</param>
+        /// <param name="messageContext">The agent message.</param>
         /// <returns></returns>
         /// <exception cref="AgentFrameworkException">Unsupported message type {messageType}</exception>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext)
         {
-            switch (messagePayload.GetMessageType())
+            switch (messageContext.GetMessageType())
             {
                 case MessageTypes.CredentialOffer:
                 {
-                    var offer = messagePayload.GetMessageAs<CredentialOfferMessage>();
+                    var offer = messageContext.GetMessage<CredentialOfferMessage>();
                     await _credentialService.ProcessOfferAsync(
-                        agentContext, offer, messagePayload.Connection);
+                        agentContext, offer, messageContext.Connection);
 
                     return null;
                 }
 
                 case MessageTypes.CredentialRequest:
                 {
-                    var request = messagePayload.GetMessageAs<CredentialRequestMessage>();
+                    var request = messageContext.GetMessage<CredentialRequestMessage>();
                     await _credentialService.ProcessCredentialRequestAsync(
-                        agentContext, request, messagePayload.Connection);
+                        agentContext, request, messageContext.Connection);
 
                     return null;
                 }
 
                 case MessageTypes.Credential:
                 {
-                    var credential = messagePayload.GetMessageAs<CredentialMessage>();
+                    var credential = messageContext.GetMessage<CredentialMessage>();
                     await _credentialService.ProcessCredentialAsync(
-                        agentContext, credential, messagePayload.Connection);
+                        agentContext, credential, messageContext.Connection);
 
                     return null;
                 }
                 default:
                     throw new AgentFrameworkException(ErrorCode.InvalidMessage,
-                        $"Unsupported message type {messagePayload.GetMessageType()}");
+                        $"Unsupported message type {messageContext.GetMessageType()}");
             }
         }
     }

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultForwardHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultForwardHandler.cs
@@ -18,10 +18,9 @@ namespace AgentFramework.Core.Handlers.Internal
         protected override async Task<AgentMessage> ProcessAsync(ForwardMessage message, IAgentContext agentContext)
         {
             var connectionRecord = await _connectionService.ResolveByMyKeyAsync(agentContext, message.To);
-            agentContext.Connection = connectionRecord;
 
             if (agentContext is AgentContext context) 
-                context.AddNext(new MessagePayload(message.Message, true));
+                context.AddNext(new MessageContext(message.Message, true, connectionRecord));
 
             return null;
         }

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultProofHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultProofHandler.cs
@@ -35,17 +35,17 @@ namespace AgentFramework.Core.Handlers.Internal
         /// <param name="messagePayload">The agent message agentContext.</param>
         /// <returns></returns>
         /// <exception cref="AgentFrameworkException">Unsupported message type {messageType}</exception>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessagePayload messagePayload)
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
         {
             switch (messagePayload.GetMessageType())
             {
                 case MessageTypes.ProofRequest:
-                    var request = messagePayload.GetMessage<ProofRequestMessage>();
-                    await _proofService.ProcessProofRequestAsync(agentContext, request);
+                    var request = messagePayload.GetMessageAs<ProofRequestMessage>();
+                    await _proofService.ProcessProofRequestAsync(agentContext, request, messagePayload.Connection);
                     break;
 
                 case MessageTypes.DisclosedProof:
-                    var proof = messagePayload.GetMessage<ProofMessage>();
+                    var proof = messagePayload.GetMessageAs<ProofMessage>();
                     await _proofService.ProcessProofAsync(agentContext, proof);
                     break;
                 default:

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultProofHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultProofHandler.cs
@@ -32,25 +32,25 @@ namespace AgentFramework.Core.Handlers.Internal
         /// Processes the agent message
         /// </summary>
         /// <param name="agentContext"></param>
-        /// <param name="messagePayload">The agent message agentContext.</param>
+        /// <param name="messageContext">The agent message agentContext.</param>
         /// <returns></returns>
         /// <exception cref="AgentFrameworkException">Unsupported message type {messageType}</exception>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext)
         {
-            switch (messagePayload.GetMessageType())
+            switch (messageContext.GetMessageType())
             {
                 case MessageTypes.ProofRequest:
-                    var request = messagePayload.GetMessageAs<ProofRequestMessage>();
-                    await _proofService.ProcessProofRequestAsync(agentContext, request, messagePayload.Connection);
+                    var request = messageContext.GetMessage<ProofRequestMessage>();
+                    await _proofService.ProcessProofRequestAsync(agentContext, request, messageContext.Connection);
                     break;
 
                 case MessageTypes.DisclosedProof:
-                    var proof = messagePayload.GetMessageAs<ProofMessage>();
+                    var proof = messageContext.GetMessage<ProofMessage>();
                     await _proofService.ProcessProofAsync(agentContext, proof);
                     break;
                 default:
                     throw new AgentFrameworkException(ErrorCode.InvalidMessage,
-                        $"Unsupported message type {messagePayload.GetMessageType()}");
+                        $"Unsupported message type {messageContext.GetMessageType()}");
             }
             return null;
         }

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultTrustPingHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultTrustPingHandler.cs
@@ -52,16 +52,16 @@ namespace AgentFramework.Core.Handlers.Internal
         /// Processes the agent message
         /// </summary>
         /// <param name="agentContext"></param>
-        /// <param name="messagePayload">The agent message agentContext.</param>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
+        /// <param name="messageContext">The agent message agentContext.</param>
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext)
         {
             await Task.Yield();
 
-            switch (messagePayload.GetMessageType())
+            switch (messageContext.GetMessageType())
             {
                 case MessageTypes.TrustPingMessageType:
                     {
-                        var pingMessage = messagePayload.GetMessageAs<TrustPingMessage>();
+                        var pingMessage = messageContext.GetMessage<TrustPingMessage>();
 
                         _eventAggregator.Publish(new ServiceMessageProcessingEvent
                         {
@@ -77,7 +77,7 @@ namespace AgentFramework.Core.Handlers.Internal
                     }
                 case MessageTypes.TrustPingResponseMessageType:
                     {
-                        var pingMessage = messagePayload.GetMessageAs<TrustPingMessage>();
+                        var pingMessage = messageContext.GetMessage<TrustPingMessage>();
 
                         _eventAggregator.Publish(new ServiceMessageProcessingEvent
                         {

--- a/src/AgentFramework.Core.Handlers/Internal/DefaultTrustPingHandler.cs
+++ b/src/AgentFramework.Core.Handlers/Internal/DefaultTrustPingHandler.cs
@@ -53,7 +53,7 @@ namespace AgentFramework.Core.Handlers.Internal
         /// </summary>
         /// <param name="agentContext"></param>
         /// <param name="messagePayload">The agent message agentContext.</param>
-        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessagePayload messagePayload)
+        public async Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
         {
             await Task.Yield();
 
@@ -61,7 +61,7 @@ namespace AgentFramework.Core.Handlers.Internal
             {
                 case MessageTypes.TrustPingMessageType:
                     {
-                        var pingMessage = messagePayload.GetMessage<TrustPingMessage>();
+                        var pingMessage = messagePayload.GetMessageAs<TrustPingMessage>();
 
                         _eventAggregator.Publish(new ServiceMessageProcessingEvent
                         {
@@ -77,7 +77,7 @@ namespace AgentFramework.Core.Handlers.Internal
                     }
                 case MessageTypes.TrustPingResponseMessageType:
                     {
-                        var pingMessage = messagePayload.GetMessage<TrustPingMessage>();
+                        var pingMessage = messagePayload.GetMessageAs<TrustPingMessage>();
 
                         _eventAggregator.Publish(new ServiceMessageProcessingEvent
                         {

--- a/src/AgentFramework.Core.Handlers/MessageHandlerBase.cs
+++ b/src/AgentFramework.Core.Handlers/MessageHandlerBase.cs
@@ -35,7 +35,7 @@ namespace AgentFramework.Core.Handlers
         protected abstract Task<AgentMessage> ProcessAsync(T message, IAgentContext agentContext);
 
         /// <inheritdoc />
-        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessagePayload messagePayload) =>
-            ProcessAsync(messagePayload.GetMessage<T>(), agentContext);
+        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload) =>
+            ProcessAsync(messagePayload.GetMessageAs<T>(), agentContext);
     }
 }

--- a/src/AgentFramework.Core.Handlers/MessageHandlerBase.cs
+++ b/src/AgentFramework.Core.Handlers/MessageHandlerBase.cs
@@ -35,7 +35,7 @@ namespace AgentFramework.Core.Handlers
         protected abstract Task<AgentMessage> ProcessAsync(T message, IAgentContext agentContext);
 
         /// <inheritdoc />
-        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload) =>
-            ProcessAsync(messagePayload.GetMessageAs<T>(), agentContext);
+        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext) =>
+            ProcessAsync(messageContext.GetMessage<T>(), agentContext);
     }
 }

--- a/src/AgentFramework.Core/Contracts/IAgentContext.cs
+++ b/src/AgentFramework.Core/Contracts/IAgentContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using AgentFramework.Core.Models;
 using AgentFramework.Core.Models.Records;
-using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.WalletApi;
 
 namespace AgentFramework.Core.Contracts
@@ -23,10 +22,5 @@ namespace AgentFramework.Core.Contracts
         /// along the execution pipeline.</summary>
         /// <value>The state.</value>
         Dictionary<string, string> State { get; set; }
-
-        /// <summary>If present, gets the connection associated
-        /// with the processed message.</summary>
-        /// <value>The connection.</value>
-        ConnectionRecord Connection { get; set; }
     }
 }

--- a/src/AgentFramework.Core/Contracts/IConnectionService.cs
+++ b/src/AgentFramework.Core/Contracts/IConnectionService.cs
@@ -64,9 +64,10 @@ namespace AgentFramework.Core.Contracts
         /// </summary>
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="request">Request.</param>
+        /// <param name="connection">Connection.</param>
         /// <exception cref="AgentFrameworkException">Throws with ErrorCode.A2AMessageTransmissionError.</exception>
         /// <returns>Connection identifier this request is related to.</returns>
-        Task<string> ProcessRequestAsync(IAgentContext agentContext, ConnectionRequestMessage request);
+        Task<string> ProcessRequestAsync(IAgentContext agentContext, ConnectionRequestMessage request, ConnectionRecord connection);
 
         /// <summary>
         /// Accepts the connection request and sends a connection response
@@ -84,8 +85,9 @@ namespace AgentFramework.Core.Contracts
         /// </summary>
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="response">Response.</param>
+        /// <param name="connection">Connection.</param>
         /// <returns>Connection identifier this request is related to.</returns>
-        Task<string> ProcessResponseAsync(IAgentContext agentContext, ConnectionResponseMessage response);
+        Task<string> ProcessResponseAsync(IAgentContext agentContext, ConnectionResponseMessage response, ConnectionRecord connection);
 
         /// <summary>
         /// Deletes a connection from the local store

--- a/src/AgentFramework.Core/Contracts/IMessageService.cs
+++ b/src/AgentFramework.Core/Contracts/IMessageService.cs
@@ -11,6 +11,16 @@ namespace AgentFramework.Core.Contracts
     public interface IMessageService
     {
         /// <summary>
+        /// Prepares a wire level message from the application level agent message for a connection asynchronously.
+        /// </summary>
+        /// <param name="wallet">The wallet.</param>
+        /// <param name="message">The message context.</param>
+        /// <param name="connection">The connection to prepare the message for.</param>
+        /// <param name="recipientKey">The recipients verkey to encrypt the message for.</param>
+        /// <returns>The response async.</returns>
+        Task<byte[]> PrepareForConnectionAsync(Wallet wallet, AgentMessage message, ConnectionRecord connection, string recipientKey = null);
+
+        /// <summary>
         /// Prepares a wire level message from the application level agent message asynchronously.
         /// </summary>
         /// <param name="wallet">The wallet.</param>
@@ -29,8 +39,9 @@ namespace AgentFramework.Core.Contracts
         /// <param name="message">The message.</param>
         /// <param name="connection">The connection record.</param>
         /// <param name="recipientKey">The recipients verkey to encrypt the message for.</param>
-        /// <returns>The response async.</returns>
-        Task SendToConnectionAsync(Wallet wallet, AgentMessage message, ConnectionRecord connection, string recipientKey = null);
+        /// <param name="requestResponse">Request response message.</param>
+        /// <returns>The response including an agent message if return routing requested async.</returns>
+        Task<byte[]> SendToConnectionAsync(Wallet wallet, AgentMessage message, ConnectionRecord connection, string recipientKey = null, bool requestResponse = false);
 
         /// <summary>
         /// Sends the agent message to the endpoint asynchronously.
@@ -41,8 +52,9 @@ namespace AgentFramework.Core.Contracts
         /// <param name="endpointUri">The destination endpoint.</param>
         /// <param name="routingKeys">The routing keys.</param>
         /// <param name="senderKey">The senders key.</param>
-        /// <returns>The response async.</returns>
-        Task SendToEndpoint(Wallet wallet, AgentMessage message, string recipientKey,
-            string endpointUri, string[] routingKeys = null, string senderKey = null);
+        /// <param name="requestResponse">Request response message.</param>
+        /// <returns>The response including an agent message if return routing requested async.</returns>
+        Task<byte[]> SendToEndpoint(Wallet wallet, AgentMessage message, string recipientKey,
+            string endpointUri, string[] routingKeys = null, string senderKey = null, bool requestResponse = false);
     }
 }

--- a/src/AgentFramework.Core/Contracts/IProofService.cs
+++ b/src/AgentFramework.Core/Contracts/IProofService.cs
@@ -41,8 +41,9 @@ namespace AgentFramework.Core.Contracts
         /// <returns>The identifier for the stored proof request.</returns>
         /// <param name="agentContext">Agent Context.</param>
         /// <param name="proofRequest">A proof request.</param>
+        /// <param name="connection">Connection.</param>
         /// <returns>Proof identifier.</returns>
-        Task<string> ProcessProofRequestAsync(IAgentContext agentContext, ProofRequestMessage proofRequest);
+        Task<string> ProcessProofRequestAsync(IAgentContext agentContext, ProofRequestMessage proofRequest, ConnectionRecord connection);
 
         /// <summary>
         /// Processes a proof and stores it for a given connection.

--- a/src/AgentFramework.Core/Decorators/Decorators.cs
+++ b/src/AgentFramework.Core/Decorators/Decorators.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AgentFramework.Core.Decorators
+{
+    /// <summary>
+    /// Decleration of attachment identifiers.
+    /// </summary>
+    public static class Decorators
+    {
+        /// <summary>
+        /// Transport decorator.
+        /// </summary>
+        public static string TransportDecorator => "transport";
+
+        /// <summary>
+        /// Threading decorator.
+        /// </summary>
+        public static string ThreadingDecorator => "thread";
+
+        /// <summary>
+        /// Attachement decorator.
+        /// </summary>
+        public static string AttachementDecorator => "attachement";
+    }
+}

--- a/src/AgentFramework.Core/Decorators/Transport/TransportDecorator.cs
+++ b/src/AgentFramework.Core/Decorators/Transport/TransportDecorator.cs
@@ -1,0 +1,47 @@
+﻿using Newtonsoft.Json;
+
+namespace AgentFramework.Core.Decorators.Transport
+{
+    /// <summary>
+    /// Return route types.
+    /// </summary>
+    public enum ReturnRouteTypes
+    {
+        /// <summary>
+        /// No messages should be returned over this connection.
+        /// </summary>
+        none,
+        /// <summary>
+        /// All messages for this key should be returned over this connection.
+        /// </summary>
+        all,
+        /// <summary>
+        /// Send all messages matching this thread over this conneciton.
+        /// </summary>
+        thread
+    }
+
+    /// <summary>
+    /// Represents an attachment decorator <code>~transport</code>
+    /// </summary>
+    public class TransportDecorator
+    {
+        /// <summary>
+        /// Return route.
+        /// </summary>
+        [JsonProperty("return_route")]
+        public string ReturnRoute { get; set; }
+
+        /// <summary>
+        /// Return route thread.
+        /// </summary>
+        [JsonProperty("return_route_thread")]
+        public string ReturnRouteThread { get; set; }
+
+        /// <summary>
+        /// Queued message count.
+        /// </summary>
+        [JsonProperty("queued_message_count")]
+        public string QueuedMessageCount { get; set; }
+    }
+}

--- a/src/AgentFramework.Core/Decorators/Transport/TransportDecoratorExtensions.cs
+++ b/src/AgentFramework.Core/Decorators/Transport/TransportDecoratorExtensions.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using AgentFramework.Core.Exceptions;
+using AgentFramework.Core.Extensions;
+using AgentFramework.Core.Messages;
+
+namespace AgentFramework.Core.Decorators.Transport
+{
+    /// <summary>
+    /// Message threading extensions.
+    /// </summary>
+    public static class TransportDecoratorExtensions
+    {
+        /// <summary>
+        /// Adds return routing to message
+        /// </summary>
+        /// <param name="message">The message to add return routing</param>
+        public static void AddReturnRouting(this AgentMessage message)
+        {
+            message.AddDecorator(new TransportDecorator
+            {
+                ReturnRoute = ReturnRouteTypes.all.ToString("G")
+            }, Decorators.TransportDecorator);
+        }
+
+        /// <summary>
+        /// Adds return routing to message
+        /// </summary>
+        /// <param name="message">The message to add return routing</param>
+        public static bool ReturnRoutingRequested(this AgentMessage message)
+        {
+            try
+            {
+                var transportDecorator = message.FindDecorator<TransportDecorator>(Decorators.TransportDecorator);
+
+                if (transportDecorator != null)
+                {
+                    return true;
+                }
+                return false;
+            }
+            catch(Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Adds return routing to message
+        /// </summary>
+        /// <param name="message">The message to add return routing</param>
+        public static bool ReturnRoutingRequested(this MessageContext message)
+        {
+            try
+            {
+                var transportDecorator = message.FindDecorator<TransportDecorator>(Decorators.TransportDecorator);
+
+                if (transportDecorator != null)
+                {
+                    return true;
+                }
+                return false;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/AgentFramework.Core/Extensions/DecoratorExtensions.cs
+++ b/src/AgentFramework.Core/Extensions/DecoratorExtensions.cs
@@ -1,0 +1,32 @@
+﻿using AgentFramework.Core.Exceptions;
+using AgentFramework.Core.Messages;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+
+namespace AgentFramework.Core.Extensions
+{
+    /// <summary>
+    /// Decorator Extensions.
+    /// </summary>
+    public static class DecoratorExtensions
+    {
+        /// <summary>
+        /// Finds the decorator with the specified name or returns <code>null</code>.
+        /// </summary>
+        /// <typeparam name="T">Type to cast the decorator to.</typeparam>
+        /// <param name="messageContext">Message Context.</param>
+        /// <param name="name">The name.</param>
+        /// <returns>The requested decorator or null</returns>
+        public static T FindDecorator<T>(this MessageContext messageContext, string name) where T : class
+        {
+            if (messageContext.Packed)
+                throw new AgentFrameworkException(ErrorCode.InvalidMessage, "Cannot fetch decorator from packed message.");
+
+            var jObject = JsonConvert.DeserializeObject<JObject>( messageContext.GetMessageJson());
+
+            var decorator = jObject.Properties().FirstOrDefault(_ => _.Name == $"~{name}");
+            return decorator?.Value.ToObject<T>();
+        }
+    }
+}

--- a/src/AgentFramework.Core/Messages/MessageContext.cs
+++ b/src/AgentFramework.Core/Messages/MessageContext.cs
@@ -99,7 +99,7 @@ namespace AgentFramework.Core.Messages
         /// </summary>
         /// <typeparam name="T">The generic type the message will be cast to.</typeparam>
         /// <returns>The agent message.</returns>
-        public T GetMessageAs<T>() where T : AgentMessage, new() =>
+        public T GetMessage<T>() where T : AgentMessage, new() =>
             Packed
                 ? throw new AgentFrameworkException(ErrorCode.InvalidMessage, "Cannot deserialize packed message.")
                 : JsonConvert.DeserializeObject<T>(_messageJson.ToString(), new AgentMessageReader<T>());

--- a/src/AgentFramework.Core/Models/DefaultAgentContext.cs
+++ b/src/AgentFramework.Core/Models/DefaultAgentContext.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using AgentFramework.Core.Contracts;
-using AgentFramework.Core.Models.Records;
 using Hyperledger.Indy.WalletApi;
 
 namespace AgentFramework.Core.Models
@@ -30,11 +27,5 @@ namespace AgentFramework.Core.Models
         /// The agent context state.
         /// </summary>
         public Dictionary<string, string> State { get; set; }
-
-        /// <inheritdoc />
-        /// <summary>
-        /// The current connection associated to the agent context.
-        /// </summary>
-        public ConnectionRecord Connection { get; set; }
     }
 }

--- a/src/AgentFramework.Core/Runtime/DefaultMessageService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultMessageService.cs
@@ -128,9 +128,7 @@ namespace AgentFramework.Core.Runtime
                 response.EnsureSuccessStatusCode();
 
                 if (response.Content != null)
-                {
                     return await response.Content.ReadAsByteArrayAsync();
-                }
             }
             catch (Exception e)
             {

--- a/src/AgentFramework.Core/Runtime/DefaultProofService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultProofService.cs
@@ -160,7 +160,7 @@ namespace AgentFramework.Core.Runtime
 
         /// <inheritdoc />
         public virtual async Task<string> ProcessProofRequestAsync(IAgentContext agentContext,
-            ProofRequestMessage proofRequest)
+            ProofRequestMessage proofRequest, ConnectionRecord connection)
         {
             var requestJson = proofRequest.ProofRequestJson;
 
@@ -169,7 +169,7 @@ namespace AgentFramework.Core.Runtime
             {
                 Id = Guid.NewGuid().ToString(),
                 RequestJson = requestJson,
-                ConnectionId = agentContext.Connection.Id,
+                ConnectionId = connection.Id,
                 State = ProofState.Requested
             };
             proofRecord.SetTag(TagConstants.LastThreadId, proofRequest.GetThreadId());

--- a/src/AgentFramework.Core/Utils/CryptoUtils.cs
+++ b/src/AgentFramework.Core/Utils/CryptoUtils.cs
@@ -76,7 +76,7 @@ namespace AgentFramework.Core.Utils
     /// <summary>
     /// Result object from <see cref="Crypto.UnpackMessageAsync"/>
     /// </summary>
-    internal class UnpackResult
+    public class UnpackResult
     {
         /// <summary>Gets or sets the message encoded as UTF8 string.</summary>
         /// <value>The message.</value>

--- a/src/AgentFramework.TestHarness/Mock/MockAgent.cs
+++ b/src/AgentFramework.TestHarness/Mock/MockAgent.cs
@@ -21,7 +21,7 @@ namespace AgentFramework.TestHarness.Mock
 
         public T GetService<T>() => ServiceProvider.GetRequiredService<T>();
 
-        public Task HandleInboundAsync(byte[] data) => ProcessAsync(data, Context);
+        public Task<byte[]> HandleInboundAsync(byte[] data) => ProcessAsync(data, Context);
 
         public async Task Dispose() => await Context.Wallet.CloseAsync();
 

--- a/src/AgentFramework.TestHarness/Mock/MockAgentRouter.cs
+++ b/src/AgentFramework.TestHarness/Mock/MockAgentRouter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace AgentFramework.TestHarness.Mock
 {
@@ -8,15 +9,16 @@ namespace AgentFramework.TestHarness.Mock
     {
         public void RegisterAgent(MockAgent agent)
         {
-            _agentInBoundCallBacks.Add((agent.Name, data => agent.HandleInboundAsync(data)));
+            Func<(string name, byte[] data), Task<byte[]>> function = async (cb) => await agent.HandleInboundAsync(cb.data);
+            _agentInBoundCallBacks.Add((agent.Name, function));
         }
 
-        public void RouteMessage(string name, byte[] data)
+        public Task<byte[]> RouteMessage(string name, byte[] data)
         {
             var result = _agentInBoundCallBacks.FirstOrDefault(_ => _.name == name);
-            result.callback.Invoke(data);
+            return result.callback.Invoke((name,data));
         }
 
-        private readonly List<(string name, Action<byte[]> callback)> _agentInBoundCallBacks = new List<(string name, Action<byte[]> callback)>();
+        private readonly List<(string name, Func<(string name, byte[] data), Task<byte[]>> callback)> _agentInBoundCallBacks = new List<(string name, Func<(string name, byte[] data), Task<byte[]>> callback)>();
     }
 }

--- a/test/AgentFramework.Core.Tests/Decorators/ThreadingDecoratorTests.cs
+++ b/test/AgentFramework.Core.Tests/Decorators/ThreadingDecoratorTests.cs
@@ -10,44 +10,8 @@ using Xunit;
 
 namespace AgentFramework.Core.Tests.Decorators
 {
-    public class ThreadingDecoratorTests : IAsyncLifetime
+    public class ThreadingDecoratorTests
     {
-        private readonly string _walletConfig = $"{{\"id\":\"{Guid.NewGuid()}\"}}";
-        private const string Credentials = "{\"key\":\"test_wallet_key\"}";
-        private IAgentContext _agent;
-
-        public async Task InitializeAsync()
-        {
-            try
-            {
-                await Wallet.CreateWalletAsync(_walletConfig, Credentials);
-            }
-            catch (WalletExistsException)
-            {
-                // OK
-            }
-
-            try
-            {
-                await Wallet.CreateWalletAsync(_walletConfig, Credentials);
-            }
-            catch (WalletExistsException)
-            {
-                // OK
-            }
-
-            _agent = new AgentContext
-            {
-                Wallet = await Wallet.OpenWalletAsync(_walletConfig, Credentials),
-            };
-        }
-
-        public async Task DisposeAsync()
-        {
-            if (_agent != null) await _agent.Wallet.CloseAsync();
-            await Wallet.DeleteWalletAsync(_walletConfig, Credentials);
-        }
-
         [Fact]
         public void CreatesNewThreadFromUnthreadedInboundMessage()
         {

--- a/test/AgentFramework.Core.Tests/Decorators/TransportDecoratorTests.cs
+++ b/test/AgentFramework.Core.Tests/Decorators/TransportDecoratorTests.cs
@@ -1,0 +1,32 @@
+﻿using AgentFramework.Core.Decorators.Transport;
+using AgentFramework.Core.Messages.Connections;
+using Xunit;
+
+namespace AgentFramework.Core.Tests.Decorators
+{
+    public class TransportDecoratorTests
+    {
+        [Fact]
+        public void CanAddTransportDecoratorToMessage()
+        {
+            var outboundMessage = new ConnectionRequestMessage();
+
+            outboundMessage.AddReturnRouting();
+
+            var transportDecorator = outboundMessage.GetDecorator<TransportDecorator>(Core.Decorators.Decorators.TransportDecorator);
+
+            Assert.NotNull(transportDecorator);
+            Assert.True(transportDecorator.ReturnRoute == ReturnRouteTypes.all.ToString("G"));
+        }
+
+        [Fact]
+        public void CanDetectTransportDecoratorOnMessage()
+        {
+            var outboundMessage = new ConnectionRequestMessage();
+
+            outboundMessage.AddReturnRouting();
+
+            Assert.True(outboundMessage.ReturnRoutingRequested());
+        }
+    }
+}

--- a/test/AgentFramework.Core.Tests/Integration/ConnectionTests.cs
+++ b/test/AgentFramework.Core.Tests/Integration/ConnectionTests.cs
@@ -19,9 +19,9 @@ namespace AgentFramework.Core.Tests.Integration
 
         public async Task InitializeAsync()
         {
-            _agent1 = await MockUtils.CreateAsync("agent1", config1, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)));
+            _agent1 = await MockUtils.CreateAsync("agent1", config1, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)));
             _router.RegisterAgent(_agent1);
-            _agent2 = await MockUtils.CreateAsync("agent2", config2, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)));
+            _agent2 = await MockUtils.CreateAsync("agent2", config2, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)));
             _router.RegisterAgent(_agent2);
         }
 
@@ -29,6 +29,12 @@ namespace AgentFramework.Core.Tests.Integration
         public async Task CanConnect()
         {
             await AgentScenarios.EstablishConnectionAsync(_agent1, _agent2);
+        }
+
+        [Fact]
+        public async Task CanConnectWithReturnRouting()
+        {
+            await AgentScenarios.EstablishConnectionWithReturnRoutingAsync(_agent1, _agent2);
         }
 
         public async Task DisposeAsync()

--- a/test/AgentFramework.Core.Tests/Integration/CredentialTests.cs
+++ b/test/AgentFramework.Core.Tests/Integration/CredentialTests.cs
@@ -21,9 +21,9 @@ namespace AgentFramework.Core.Tests.Integration
 
         public async Task InitializeAsync()
         {
-            _issuerAgent = await MockUtils.CreateAsync("issuer", config1, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)), TestConstants.StewartDid);
+            _issuerAgent = await MockUtils.CreateAsync("issuer", config1, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)), TestConstants.StewartDid);
             _router.RegisterAgent(_issuerAgent);
-            _holderAgent = await MockUtils.CreateAsync("holder", config2, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)));
+            _holderAgent = await MockUtils.CreateAsync("holder", config2, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage((cb).name, cb.data)));
             _router.RegisterAgent(_holderAgent);
         }
 

--- a/test/AgentFramework.Core.Tests/Integration/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/Integration/ProofTests.cs
@@ -24,11 +24,11 @@ namespace AgentFramework.Core.Tests.Integration
 
         public async Task InitializeAsync()
         {
-            _issuerAgent = await MockUtils.CreateAsync("issuer", config1, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)), TestConstants.StewartDid);
+            _issuerAgent = await MockUtils.CreateAsync("issuer", config1, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)), TestConstants.StewartDid);
             _router.RegisterAgent(_issuerAgent);
-            _holderAgent = await MockUtils.CreateAsync("holder", config2, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)));
+            _holderAgent = await MockUtils.CreateAsync("holder", config2, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)));
             _router.RegisterAgent(_holderAgent);
-            _requestorAgent = await MockUtils.CreateAsync("requestor", config3, cred, new MockAgentHttpHandler((name, data) => _router.RouteMessage(name, data)));
+            _requestorAgent = await MockUtils.CreateAsync("requestor", config3, cred, new MockAgentHttpHandler((cb) => _router.RouteMessage(cb.name, cb.data)));
             _router.RegisterAgent(_requestorAgent);
         }
 

--- a/test/AgentFramework.Core.Tests/MockExtendedConnectionService.cs
+++ b/test/AgentFramework.Core.Tests/MockExtendedConnectionService.cs
@@ -5,7 +5,6 @@ using AgentFramework.Core.Messages.Connections;
 using AgentFramework.Core.Models.Connections;
 using AgentFramework.Core.Models.Records;
 using AgentFramework.Core.Models.Records.Search;
-using Hyperledger.Indy.WalletApi;
 
 namespace AgentFramework.Core.Tests
 {
@@ -36,7 +35,7 @@ namespace AgentFramework.Core.Tests
             throw new System.NotImplementedException();
         }
 
-        public Task<string> ProcessRequestAsync(IAgentContext agentContext, ConnectionRequestMessage request)
+        public Task<string> ProcessRequestAsync(IAgentContext agentContext, ConnectionRequestMessage request, ConnectionRecord connection)
         {
             throw new System.NotImplementedException();
         }
@@ -51,7 +50,7 @@ namespace AgentFramework.Core.Tests
             throw new System.NotImplementedException();
         }
 
-        public Task<string> ProcessResponseAsync(IAgentContext agentContext, ConnectionResponseMessage response)
+        public Task<string> ProcessResponseAsync(IAgentContext agentContext, ConnectionResponseMessage response, ConnectionRecord connection)
         {
             throw new System.NotImplementedException();
         }

--- a/test/AgentFramework.Core.Tests/MockMessageHandler.cs
+++ b/test/AgentFramework.Core.Tests/MockMessageHandler.cs
@@ -10,7 +10,7 @@ namespace AgentFramework.Core.Tests
     public class MockMessageHandler : IMessageHandler
     {
         public IEnumerable<string> SupportedMessageTypes { get; }
-        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
+        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messageContext)
         {
             throw new NotImplementedException();
         }

--- a/test/AgentFramework.Core.Tests/MockMessageHandler.cs
+++ b/test/AgentFramework.Core.Tests/MockMessageHandler.cs
@@ -10,7 +10,7 @@ namespace AgentFramework.Core.Tests
     public class MockMessageHandler : IMessageHandler
     {
         public IEnumerable<string> SupportedMessageTypes { get; }
-        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessagePayload messagePayload)
+        public Task<AgentMessage> ProcessAsync(IAgentContext agentContext, MessageContext messagePayload)
         {
             throw new NotImplementedException();
         }

--- a/test/AgentFramework.Core.Tests/Protocols/ConnectionTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/ConnectionTests.cs
@@ -103,7 +103,6 @@ namespace AgentFramework.Core.Tests.Protocols
 
             //Process a connection request
             var connectionRecord = await _connectionService.GetAsync(_issuerWallet, connectionId);
-            _issuerWallet.Connection = connectionRecord;
 
             await _connectionService.ProcessRequestAsync(_issuerWallet, new ConnectionRequestMessage
             {
@@ -114,7 +113,7 @@ namespace AgentFramework.Core.Tests.Protocols
                         MyVk = "6vyxuqpe3UBcTmhF3Wmmye2UVroa51Lcd9smQKFB5QX1"
                     }.MyDidDoc(await _provisioningService.GetProvisioningAsync(_issuerWallet.Wallet))
                 }
-            });
+            }, connectionRecord);
 
             //Accept the connection request
             await _connectionService.CreateResponseAsync(_issuerWallet, connectionId);
@@ -142,7 +141,7 @@ namespace AgentFramework.Core.Tests.Protocols
 
             //Process a connection request
             var connectionRecord = await _connectionService.GetAsync(_issuerWallet, connectionId);
-            _issuerWallet.Connection = connectionRecord;
+
             await _connectionService.ProcessRequestAsync(_issuerWallet, new ConnectionRequestMessage
             {
                 Connection = new Connection { 
@@ -152,7 +151,7 @@ namespace AgentFramework.Core.Tests.Protocols
                         MyVk = "6vyxuqpe3UBcTmhF3Wmmye2UVroa51Lcd9smQKFB5QX1"
                     }.MyDidDoc(await _provisioningService.GetProvisioningAsync(_issuerWallet.Wallet))
                 }
-            });
+            }, connectionRecord);
 
             //Accept the connection request
             await _connectionService.CreateResponseAsync(_issuerWallet, connectionId);

--- a/test/AgentFramework.Core.Tests/Protocols/EphemeralChallengeTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/EphemeralChallengeTests.cs
@@ -53,15 +53,15 @@ namespace AgentFramework.Core.Tests.Protocols
 
             var routingMock = new Mock<IMessageService>();
             routingMock.Setup(x =>
-                    x.SendToConnectionAsync(It.IsAny<Wallet>(), It.IsAny<AgentMessage>(), It.IsAny<ConnectionRecord>(), It.IsAny<string>()))
-                .Callback((Wallet _, AgentMessage content, ConnectionRecord __, string ___) =>
+                    x.SendToConnectionAsync(It.IsAny<Wallet>(), It.IsAny<AgentMessage>(), It.IsAny<ConnectionRecord>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Callback((Wallet _, AgentMessage content, ConnectionRecord __, string ___, bool ____) =>
                 {
                     if (_routeMessage)
                         _messages.Add(content);
                     else
                         throw new AgentFrameworkException(ErrorCode.LedgerOperationRejected, "");
                 })
-                .Returns(Task.FromResult(false));
+                .Returns(Task.FromResult<byte[]>(null));
 
             var provisioningMock = ServiceUtils.GetDefaultMockProvisioningService();
 

--- a/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
@@ -200,7 +200,6 @@ namespace AgentFramework.Core.Tests.Protocols
             var (issuerConnection, _) = await Scenarios.EstablishConnectionAsync(
                 _connectionService, _messages, _issuerWallet, _holderWallet);
 
-            _issuerWallet.Connection = issuerConnection;
             var ex = await Assert.ThrowsAsync<AgentFrameworkException>(async () =>
                 await _proofService.ProcessProofAsync(_issuerWallet, new ProofMessage()));
 
@@ -252,9 +251,8 @@ namespace AgentFramework.Core.Tests.Protocols
                 var proofRequest = FindContentMessage<ProofRequestMessage>();
                 Assert.NotNull(proofRequest);
 
-                _holderWallet.Connection = holderConnection;
                 //Holder stores the proof request
-                var holderProofRequestId = await _proofService.ProcessProofRequestAsync(_holderWallet, proofRequest);
+                var holderProofRequestId = await _proofService.ProcessProofRequestAsync(_holderWallet, proofRequest, holderConnection);
                 var holderProofRecord = await _proofService.GetAsync(_holderWallet, holderProofRequestId);
                 var holderProofObject =
                     JsonConvert.DeserializeObject<ProofRequest>(holderProofRecord.RequestJson);
@@ -299,7 +297,6 @@ namespace AgentFramework.Core.Tests.Protocols
             var proof = FindContentMessage<ProofMessage>();
             Assert.NotNull(proof);
 
-            _requestorWallet.Connection = requestorConnection;
             //Requestor stores proof
             await _proofService.ProcessProofAsync(_requestorWallet, proof);
 
@@ -359,9 +356,8 @@ namespace AgentFramework.Core.Tests.Protocols
             var proofRequest = FindContentMessage<ProofRequestMessage>();
             Assert.NotNull(proofRequest);
 
-            _holderWallet.Connection = holderConnection;
             //Holder stores the proof request
-            var holderProofRequestId = await _proofService.ProcessProofRequestAsync(_holderWallet, proofRequest);
+            var holderProofRequestId = await _proofService.ProcessProofRequestAsync(_holderWallet, proofRequest, holderConnection);
             var holderProofRecord = await _proofService.GetAsync(_holderWallet, holderProofRequestId);
             var holderProofObject =
                 JsonConvert.DeserializeObject<ProofRequest>(holderProofRecord.RequestJson);
@@ -454,9 +450,8 @@ namespace AgentFramework.Core.Tests.Protocols
             var proofRequest = FindContentMessage<ProofRequestMessage>();
             Assert.NotNull(proofRequest);
 
-            _holderWallet.Connection = holderConnection;
             //Holder stores the proof request
-            var holderProofRequestId = await _proofService.ProcessProofRequestAsync(_holderWallet, proofRequest);
+            var holderProofRequestId = await _proofService.ProcessProofRequestAsync(_holderWallet, proofRequest, holderConnection);
 
             //Holder accepts the proof request and sends a proof
             await _proofService.RejectProofRequestAsync(_holderWallet, holderProofRequestId);


### PR DESCRIPTION
#### Short description of what this resolves:

This PR adds return routing support and implements the concept for messages transmitted over HTTP.

#### Changes proposed in this pull request:

- Renames MessagePayload -> MessageContext
- Shifts the connection from AgentContext to MessageContext
- Adds transport decorator and extensions
- Extends DefaultMessageService to handle return routing messages
- Modify AgentMessageProcessorBase to handle returned messages
- Adds required tests

**Closes**: #123
