### PR TITLE
docs(github): Delete default example github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,7 +1,0 @@
----
-name: Custom issue template
-about: Describe this issue template's purpose here.
-
----
-
-


### PR DESCRIPTION
#### Short description of what this resolves:
Removes the example issue template (custom issue template)

![issue template creation list](https://user-images.githubusercontent.com/14815230/57994687-74c1da80-7b12-11e9-853d-ac7212086f54.png)


#### Changes proposed in this pull request:

- Remove issue template with default values
-
-


