### PR TITLE
Refactor namespaces and extensions

### DIFF
--- a/src/AgentFramework.AspNetCore/AgentFramework.AspNetCore.csproj
+++ b/src/AgentFramework.AspNetCore/AgentFramework.AspNetCore.csproj
@@ -16,8 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />

--- a/src/AgentFramework.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/AgentFramework.AspNetCore/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using AgentFramework.AspNetCore.Middleware;
+using AgentFramework.Core.Handlers.Agents;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,7 +14,8 @@ namespace AgentFramework.AspNetCore
         /// Allows default agent configuration
         /// </summary>
         /// <param name="app">App.</param>
-        public static void UseAgentFramework(this IApplicationBuilder app) => UseAgentFramework<AgentMiddleware>(app);
+        public static void UseAgentFramework(this IApplicationBuilder app) => app.Use((context, func) =>
+            AgentMiddleware.InvokeAsync(context, func, app.ApplicationServices.GetService<IAgentProvider>()));
 
         /// <summary>
         /// Allows agent configuration by specifying a custom middleware

--- a/src/AgentFramework.AspNetCore/Runtime/MemoryCacheLedgerService.cs
+++ b/src/AgentFramework.AspNetCore/Runtime/MemoryCacheLedgerService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using Hyperledger.Indy.LedgerApi;
 using Hyperledger.Indy.PoolApi;

--- a/src/AgentFramework.Core.Handlers/AgentFramework.Core.Handlers.csproj
+++ b/src/AgentFramework.Core.Handlers/AgentFramework.Core.Handlers.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AgentFramework.Core\AgentFramework.Core.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/AgentFramework.Core.Handlers/AgentFrameworkBuilderExtensions.cs
+++ b/src/AgentFramework.Core.Handlers/AgentFrameworkBuilderExtensions.cs
@@ -1,109 +1,122 @@
 ﻿using System;
-using AgentFramework.AspNetCore.Hosting;
+using AgentFramework.Core.Configuration;
+using AgentFramework.Core.Configuration.Options;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Handlers;
 using AgentFramework.Core.Handlers.Agents;
-using AgentFramework.Core.Models;
+using AgentFramework.Core.Handlers.Hosting;
 using AgentFramework.Core.Models.Wallets;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
-namespace AgentFramework.AspNetCore
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Agent builder extensions.
     /// </summary>
-    public static class AgentBuilderExtensions
+    public static class AgentFrameworkBuilderExtensions
     {
         /// <summary>
         /// Adds a <see cref="DefaultAgent"/> service provisioned with <see cref="BasicProvisioningConfiguration"/>
         /// </summary>
         /// <returns>The basic agent.</returns>
-        /// <param name="builder">Builder.</param>
+        /// <param name="frameworkBuilder">Builder.</param>
         /// <param name="config">Config.</param>
-        public static AgentBuilder AddBasicAgent(this AgentBuilder builder, Action<BasicProvisioningConfiguration> config)
+        public static AgentFrameworkBuilder AddBasicAgent(this AgentFrameworkBuilder frameworkBuilder, Action<BasicProvisioningConfiguration> config)
         {
-            return AddBasicAgent<DefaultAgent>(builder, config);
+            return AddBasicAgent<DefaultAgent>(frameworkBuilder, config);
         }
 
         /// <summary>
         /// Adds a custom agent service provisioned with <see cref="BasicProvisioningConfiguration"/>
         /// </summary>
         /// <returns>The basic agent.</returns>
-        /// <param name="builder">Builder.</param>
+        /// <param name="frameworkBuilder">Builder.</param>
         /// <param name="config">Config.</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static AgentBuilder AddBasicAgent<T>(this AgentBuilder builder, Action<BasicProvisioningConfiguration> config)
+        public static AgentFrameworkBuilder AddBasicAgent<T>(this AgentFrameworkBuilder frameworkBuilder, Action<BasicProvisioningConfiguration> config)
             where T : class, IAgent
         {
             var configuration = new BasicProvisioningConfiguration();
             config?.Invoke(configuration);
 
-            return AddAgent<T, BasicProvisioningConfiguration>(builder, () => configuration);
+            return AddAgent<T, BasicProvisioningConfiguration>(frameworkBuilder, () => configuration);
         }
 
         /// <summary>
         /// Adds a <see cref="DefaultAgent"/> service provisioned with <see cref="IssuerProvisioningConfiguration"/>
         /// </summary>
         /// <returns>The issuer agent.</returns>
-        /// <param name="builder">Builder.</param>
+        /// <param name="frameworkBuilder">Builder.</param>
         /// <param name="config">Config.</param>
-        public static AgentBuilder AddIssuerAgent(this AgentBuilder builder, Action<IssuerProvisioningConfiguration> config)
+        public static AgentFrameworkBuilder AddIssuerAgent(this AgentFrameworkBuilder frameworkBuilder, Action<IssuerProvisioningConfiguration> config)
         {
-            return AddIssuerAgent<DefaultAgent>(builder, config);
+            return AddIssuerAgent<DefaultAgent>(frameworkBuilder, config);
         }
 
         /// <summary>
         /// Adds a custom agent service provisioned with <see cref="IssuerProvisioningConfiguration"/>
         /// </summary>
         /// <returns>The issuer agent.</returns>
-        /// <param name="builder">Builder.</param>
+        /// <param name="frameworkBuilder">Builder.</param>
         /// <param name="config">Config.</param>
         /// <typeparam name="T">The 1st type parameter.</typeparam>
-        public static AgentBuilder AddIssuerAgent<T>(this AgentBuilder builder, Action<IssuerProvisioningConfiguration> config)
+        public static AgentFrameworkBuilder AddIssuerAgent<T>(this AgentFrameworkBuilder frameworkBuilder, Action<IssuerProvisioningConfiguration> config)
             where T : class, IAgent
         {
             var configuration = new IssuerProvisioningConfiguration();
             config?.Invoke(configuration);
 
-            return AddAgent<T, IssuerProvisioningConfiguration>(builder, () => configuration);
+            return AddAgent<T, IssuerProvisioningConfiguration>(frameworkBuilder, () => configuration);
         }
 
         /// <summary>
         /// Adds a custom agent service provisioned with custom <see cref="ProvisioningConfiguration"/>
         /// </summary>
         /// <returns>The agent.</returns>
-        /// <param name="builder">Builder.</param>
+        /// <param name="frameworkBuilder">Builder.</param>
         /// <param name="createConfiguration">Create configuration.</param>
         /// <typeparam name="TAgent">The 1st type parameter.</typeparam>
         /// <typeparam name="TConfiguration">The 2nd type parameter.</typeparam>
-        public static AgentBuilder AddAgent<TAgent, TConfiguration>(this AgentBuilder builder, Func<TConfiguration> createConfiguration)
+        public static AgentFrameworkBuilder AddAgent<TAgent, TConfiguration>(this AgentFrameworkBuilder frameworkBuilder, Func<TConfiguration> createConfiguration)
             where TAgent : class, IAgent
             where TConfiguration : ProvisioningConfiguration
         {
             var configuration = createConfiguration.Invoke();
 
-            builder.Services.Configure<WalletOptions>(obj =>
+            frameworkBuilder.Services.Configure<WalletOptions>(obj =>
             {
                 obj.WalletConfiguration = configuration.WalletConfiguration;
                 obj.WalletCredentials = configuration.WalletCredentials;
             });
 
-            builder.Services.Configure<PoolOptions>(obj =>
+            frameworkBuilder.Services.Configure<PoolOptions>(obj =>
             {
                 obj.PoolName = configuration.PoolName;
                 obj.GenesisFilename = configuration.GenesisFilename;
             });
 
-            builder.Services.AddSingleton<ProvisioningConfiguration>(configuration);
-            builder.Services.AddSingleton<IAgent, TAgent>();
-            builder.Services.AddSingleton<IHostedService>(s => new AgentHostedService(
+            frameworkBuilder.AddAgentProvider();
+            frameworkBuilder.Services.AddDefaultMessageHandlers();
+            frameworkBuilder.Services.AddSingleton<ProvisioningConfiguration>(configuration);
+            frameworkBuilder.Services.AddSingleton<IAgent, TAgent>();
+            frameworkBuilder.Services.AddSingleton<IHostedService>(s => new ProvisioningHostedService(
                 configuration,
                 s.GetRequiredService<IProvisioningService>(),
                 s.GetRequiredService<IPoolService>(),
                 s.GetRequiredService<IOptions<PoolOptions>>()));
 
+            return frameworkBuilder;
+        }
+
+        /// <summary>
+        /// Adds agent provider services
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static AgentFrameworkBuilder AddAgentProvider(this AgentFrameworkBuilder builder)
+        {
+            builder.Services.AddSingleton<IAgentProvider, DefaultAgentProvider>();
             return builder;
         }
     }

--- a/src/AgentFramework.Core.Handlers/Agents/DefaultAgentProvider.cs
+++ b/src/AgentFramework.Core.Handlers/Agents/DefaultAgentProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using AgentFramework.Core.Configuration.Options;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Models;
 using Microsoft.Extensions.Options;

--- a/src/AgentFramework.Core.Handlers/Hosting/ProvisioningHostedService.cs
+++ b/src/AgentFramework.Core.Handlers/Hosting/ProvisioningHostedService.cs
@@ -1,21 +1,21 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using AgentFramework.Core.Configuration.Options;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Exceptions;
-using AgentFramework.Core.Models;
 using AgentFramework.Core.Models.Wallets;
 using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.WalletApi;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
-namespace AgentFramework.AspNetCore.Hosting
+namespace AgentFramework.Core.Handlers.Hosting
 {
     /// <inheritdoc />
     /// <summary>
     /// Agent hosted service.
     /// </summary>
-    public class AgentHostedService : IHostedService
+    public class ProvisioningHostedService : IHostedService
     {
         private readonly IProvisioningService _provisioningService;
         private readonly IPoolService _poolService;
@@ -28,7 +28,7 @@ namespace AgentFramework.AspNetCore.Hosting
         /// <param name="provisioningConfiguration">Provisioning configuration.</param>
         /// <param name="poolService">Pool service.</param>
         /// <param name="poolOptions">Pool options.</param>
-        public AgentHostedService(
+        public ProvisioningHostedService(
             ProvisioningConfiguration provisioningConfiguration,
             IProvisioningService provisioningService,
             IPoolService poolService,

--- a/src/AgentFramework.Core.Handlers/ServiceCollectionExtensions.cs
+++ b/src/AgentFramework.Core.Handlers/ServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+﻿using AgentFramework.Core.Handlers;
+using AgentFramework.Core.Handlers.Agents;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Service collection extensions
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds the message handler.
+        /// </summary>
+        /// <returns>The message handler.</returns>
+        /// <param name="builder">Builder.</param>
+        /// <typeparam name="TMessageHandler">The 1st type parameter.</typeparam>
+        public static IServiceCollection AddMessageHandler<TMessageHandler>(this IServiceCollection builder) where TMessageHandler : class,
+            IMessageHandler
+        {
+            builder.AddSingleton<IMessageHandler, TMessageHandler>();
+            builder.TryAddSingleton<TMessageHandler>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Overrides the default agent provider.
+        /// </summary>
+        /// <returns>The default agent provider.</returns>
+        /// <param name="builder">Builder.</param>
+        /// <typeparam name="TProvider">The 1st type parameter.</typeparam>
+        public static IServiceCollection OverrideDefaultAgentProvider<TProvider>(
+            this IServiceCollection builder)
+            where TProvider : class, IAgentProvider
+        {
+            builder.AddSingleton<IAgentProvider, TProvider>();
+            return builder;
+        }
+    }
+}

--- a/src/AgentFramework.Core/Configuration/AgentFrameworkBuilder.cs
+++ b/src/AgentFramework.Core/Configuration/AgentFrameworkBuilder.cs
@@ -1,19 +1,19 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace AgentFramework.Core.Handlers
+namespace AgentFramework.Core.Configuration
 {
     /// <summary>
     /// Agent Configuration Builder
     /// </summary>
-    public class AgentBuilder
+    public class AgentFrameworkBuilder
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AgentBuilder"/> class.
+        /// Initializes a new instance of the <see cref="AgentFrameworkBuilder"/> class.
         /// </summary>
         /// <param name="services">The services.</param>
         /// <exception cref="System.ArgumentNullException">services</exception>
-        internal AgentBuilder(IServiceCollection services)
+        internal AgentFrameworkBuilder(IServiceCollection services)
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
         }

--- a/src/AgentFramework.Core/Configuration/Options/PoolOptions.cs
+++ b/src/AgentFramework.Core/Configuration/Options/PoolOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace AgentFramework.Core.Models
+﻿namespace AgentFramework.Core.Configuration.Options
 {
     /// <summary>
     /// Pool options.

--- a/src/AgentFramework.Core/Configuration/Options/WalletOptions.cs
+++ b/src/AgentFramework.Core/Configuration/Options/WalletOptions.cs
@@ -1,6 +1,6 @@
 ﻿using AgentFramework.Core.Models.Wallets;
 
-namespace AgentFramework.Core.Models
+namespace AgentFramework.Core.Configuration.Options
 {
     /// <summary>Wallet options</summary>
     public class WalletOptions

--- a/src/AgentFramework.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/AgentFramework.Core/Configuration/ServiceCollectionExtensions.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Net.Http;
-using AgentFramework.AspNetCore.Middleware;
+using AgentFramework.Core.Configuration;
+using AgentFramework.Core.Configuration.Options;
 using AgentFramework.Core.Contracts;
-using AgentFramework.Core.Handlers;
-using AgentFramework.Core.Handlers.Agents;
-using AgentFramework.Core.Models;
 using AgentFramework.Core.Runtime;
 using AgentFramework.Core.Runtime.Transport;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace AgentFramework.AspNetCore
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Service builder extensions.
@@ -25,11 +23,9 @@ namespace AgentFramework.AspNetCore
         {
             services.AddOptions<WalletOptions>();
             services.AddOptions<PoolOptions>();
-            services.AddSingleton<AgentMiddleware>();
             services.AddLogging();
 
             services.AddDefaultServices();
-            services.AddDefaultMessageHandlers();
         }
 
         /// <summary>
@@ -37,17 +33,15 @@ namespace AgentFramework.AspNetCore
         /// </summary>
         /// <param name="services">Services.</param>
         /// <param name="builder">Builder.</param>
-        public static void AddAgentFramework(this IServiceCollection services, Action<AgentBuilder> builder)
+        public static void AddAgentFramework(this IServiceCollection services, Action<AgentFrameworkBuilder> builder)
         {
             AddAgentFramework(services);
-            builder.Invoke(new AgentBuilder(services));
+            builder.Invoke(new AgentFrameworkBuilder(services));
         }
 
         internal static IServiceCollection AddDefaultServices(this IServiceCollection builder)
         {
             builder.TryAddSingleton<IEventAggregator, EventAggregator>();
-            builder.TryAddSingleton<IAgentProvider, DefaultAgentProvider>();
-            builder.TryAddSingleton<IAgent, DefaultAgent>();
             builder.TryAddSingleton<IConnectionService, DefaultConnectionService>();
             builder.TryAddSingleton<ICredentialService, DefaultCredentialService>();
             builder.TryAddSingleton<ILedgerService, DefaultLedgerService>();
@@ -65,34 +59,6 @@ namespace AgentFramework.AspNetCore
             builder.TryAddSingleton<IWalletService, DefaultWalletService>();
             builder.TryAddSingleton<IPaymentService, DefaultPaymentService>();
 
-            return builder;
-        }
-
-        /// <summary>
-        /// Adds the message handler.
-        /// </summary>
-        /// <returns>The message handler.</returns>
-        /// <param name="builder">Builder.</param>
-        /// <typeparam name="TMessageHandler">The 1st type parameter.</typeparam>
-        public static IServiceCollection AddMessageHandler<TMessageHandler>(this IServiceCollection builder) where TMessageHandler : class,
-            IMessageHandler
-        {
-            builder.AddSingleton<IMessageHandler, TMessageHandler>();
-            builder.TryAddSingleton<TMessageHandler>();
-            return builder;
-        }
-
-        /// <summary>
-        /// Overrides the default agent context provider.
-        /// </summary>
-        /// <returns>The default agent context provider.</returns>
-        /// <param name="builder">Builder.</param>
-        /// <typeparam name="TProvider">The 1st type parameter.</typeparam>
-        public static IServiceCollection OverrideDefaultAgentContextProvider<TProvider>(
-            this IServiceCollection builder)
-            where TProvider : class, IAgentProvider
-        {
-            builder.AddSingleton<IAgentProvider, TProvider>();
             return builder;
         }
 

--- a/src/AgentFramework.Payments.NullPay/AgentBuilderExtensions.cs
+++ b/src/AgentFramework.Payments.NullPay/AgentBuilderExtensions.cs
@@ -1,14 +1,14 @@
-﻿using AgentFramework.Core.Handlers;
+﻿using AgentFramework.Core.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AgentFramework.Payments.NullPay
 {
     public static class AgentBuilderExtensions
     {
-        public static AgentBuilder AddNullPay(this AgentBuilder agentBuilder)
+        public static AgentFrameworkBuilder AddNullPay(this AgentFrameworkBuilder agentFrameworkBuilder)
         {
-            agentBuilder.Services.AddHostedService<NullPayConfigurationService>();
-            return agentBuilder;
+            agentFrameworkBuilder.Services.AddHostedService<NullPayConfigurationService>();
+            return agentFrameworkBuilder;
         }
     }
 }

--- a/src/AgentFramework.Payments.SovrinToken/AgentBuilderExtensions.cs
+++ b/src/AgentFramework.Payments.SovrinToken/AgentBuilderExtensions.cs
@@ -1,5 +1,5 @@
-﻿using AgentFramework.Core.Contracts;
-using AgentFramework.Core.Handlers;
+﻿using AgentFramework.Core.Configuration;
+using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Handlers.Agents;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -7,12 +7,12 @@ namespace AgentFramework.Payments.SovrinToken
 {
     public static class AgentBuilderExtensions
     {
-        public static AgentBuilder AddSovrinToken(this AgentBuilder agentBuilder)
+        public static AgentFrameworkBuilder AddSovrinToken(this AgentFrameworkBuilder agentFrameworkBuilder)
         {
-            agentBuilder.Services.AddHostedService<SovrinTokenConfigurationService>();
-            agentBuilder.Services.AddSingleton<IPaymentService, SovrinPaymentService>();
-            agentBuilder.Services.AddSingleton<IAgentMiddleware, PaymentsAgentMiddleware>();
-            return agentBuilder;
+            agentFrameworkBuilder.Services.AddHostedService<SovrinTokenConfigurationService>();
+            agentFrameworkBuilder.Services.AddSingleton<IPaymentService, SovrinPaymentService>();
+            agentFrameworkBuilder.Services.AddSingleton<IAgentMiddleware, PaymentsAgentMiddleware>();
+            return agentFrameworkBuilder;
         }
     }
 }

--- a/src/AgentFramework.TestHarness/Mock/InProcAgent.cs
+++ b/src/AgentFramework.TestHarness/Mock/InProcAgent.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using AgentFramework.AspNetCore;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Handlers;
 using AgentFramework.Core.Handlers.Agents;

--- a/src/AgentFramework.TestHarness/Mock/InProcMessageHandler.cs
+++ b/src/AgentFramework.TestHarness/Mock/InProcMessageHandler.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 
 namespace AgentFramework.TestHarness.Mock

--- a/src/AgentFramework.TestHarness/Mock/MockAgentHttpHandler.cs
+++ b/src/AgentFramework.TestHarness/Mock/MockAgentHttpHandler.cs
@@ -1,5 +1,4 @@
 ﻿using AgentFramework.Core.Handlers;
-using AgentFramework.Core.Handlers.Agents;
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/AgentFramework.TestHarness/Mock/MockUtils.cs
+++ b/src/AgentFramework.TestHarness/Mock/MockUtils.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using AgentFramework.Core.Contracts;
+using AgentFramework.Core.Handlers;
 using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Models;
 using AgentFramework.Core.Models.Wallets;
@@ -17,6 +18,7 @@ namespace AgentFramework.TestHarness.Mock
             var services = new ServiceCollection();
 
             services.AddAgentFramework();
+            services.AddDefaultMessageHandlers();
             services.AddLogging();
             services.AddSingleton<MockAgentMessageProcessor>();
             services.AddSingleton<HttpMessageHandler>(handler);

--- a/src/AgentFramework.TestHarness/Mock/MockUtils.cs
+++ b/src/AgentFramework.TestHarness/Mock/MockUtils.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using AgentFramework.AspNetCore;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Models;

--- a/src/AgentFramework.TestHarness/TestSingleWallet.cs
+++ b/src/AgentFramework.TestHarness/TestSingleWallet.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using AgentFramework.AspNetCore;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Payments.SovrinToken;
 using Hyperledger.Indy.WalletApi;
@@ -11,7 +10,7 @@ using AgentFramework.Core.Extensions;
 using AgentFramework.Core.Models.Wallets;
 using AgentFramework.Core.Handlers.Agents;
 using System.IO;
-using AgentFramework.Core.Models;
+using AgentFramework.Core.Configuration.Options;
 using Microsoft.Extensions.Options;
 using Hyperledger.Indy.PoolApi;
 using Hyperledger.Indy.DidApi;
@@ -55,17 +54,16 @@ namespace AgentFramework.TestHarness
                 {
                     services.Configure<ConsoleLifetimeOptions>(options =>
                         options.SuppressStatusMessages = true);
-                    services.AddAgentFramework(builder =>
-                        builder
-                            .AddIssuerAgent(config =>
-                            {
-                                config.EndpointUri = new Uri("http://test");
-                                config.WalletConfiguration = new WalletConfiguration { Id = Guid.NewGuid().ToString() };
-                                config.WalletCredentials = new WalletCredentials { Key = "test" };
-                                config.GenesisFilename = Path.GetFullPath("pool_genesis.txn");
-                                config.PoolName = "TestPool";
-                            })
-                            .AddSovrinToken());
+                    services.AddAgentFramework(builder => builder
+                        .AddIssuerAgent(config =>
+                        {
+                            config.EndpointUri = new Uri("http://test");
+                            config.WalletConfiguration = new WalletConfiguration {Id = Guid.NewGuid().ToString()};
+                            config.WalletCredentials = new WalletCredentials {Key = "test"};
+                            config.GenesisFilename = Path.GetFullPath("pool_genesis.txn");
+                            config.PoolName = "TestPool";
+                        })
+                        .AddSovrinToken());
                 })
                 .Build();
 
@@ -75,7 +73,7 @@ namespace AgentFramework.TestHarness
             Context = await Host.Services.GetService<IAgentProvider>().GetContextAsync();
 
             Trustee = await Did.CreateAndStoreMyDidAsync(Context.Wallet,
-                new { seed = "000000000000000000000000Trustee1" }.ToJson());
+                new {seed = "000000000000000000000000Trustee1"}.ToJson());
             Trustee2 = await PromoteTrustee("000000000000000000000000Trustee2");
             Trustee3 = await PromoteTrustee("000000000000000000000000Trustee3");
 

--- a/src/AgentFramework.TestHarness/Utils/PoolUtils.cs
+++ b/src/AgentFramework.TestHarness/Utils/PoolUtils.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using AgentFramework.Core.Contracts;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using Hyperledger.Indy.PoolApi;
 

--- a/test/AgentFramework.Core.Tests/ConfigurationTests.cs
+++ b/test/AgentFramework.Core.Tests/ConfigurationTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using AgentFramework.AspNetCore;
 using AgentFramework.AspNetCore.Middleware;
 using AgentFramework.Core.Extensions;
 using AgentFramework.Core.Contracts;

--- a/test/AgentFramework.Core.Tests/EventAggregatorTests.cs
+++ b/test/AgentFramework.Core.Tests/EventAggregatorTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reactive.Linq;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using Xunit;
 

--- a/test/AgentFramework.Core.Tests/MessageServiceTests.cs
+++ b/test/AgentFramework.Core.Tests/MessageServiceTests.cs
@@ -15,7 +15,6 @@ using AgentFramework.Core.Models;
 using AgentFramework.Core.Models.Connections;
 using AgentFramework.Core.Models.Records;
 using AgentFramework.Core.Models.Records.Search;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using AgentFramework.Core.Runtime.Transport;
 using AgentFramework.Core.Utils;

--- a/test/AgentFramework.Core.Tests/Protocols/ConnectionTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/ConnectionTests.cs
@@ -10,7 +10,6 @@ using AgentFramework.Core.Messages.Connections;
 using AgentFramework.Core.Models.Connections;
 using AgentFramework.Core.Models.Events;
 using AgentFramework.Core.Models.Records;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using AgentFramework.TestHarness;
 using AgentFramework.TestHarness.Utils;

--- a/test/AgentFramework.Core.Tests/Protocols/CredentialTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/CredentialTests.cs
@@ -14,7 +14,6 @@ using AgentFramework.Core.Models.Connections;
 using AgentFramework.Core.Models.Credentials;
 using AgentFramework.Core.Models.Events;
 using AgentFramework.Core.Models.Records;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.TestHarness;
 using AgentFramework.TestHarness.Utils;
 using Hyperledger.Indy.AnonCredsApi;

--- a/test/AgentFramework.Core.Tests/Protocols/DiscoveryTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/DiscoveryTests.cs
@@ -1,5 +1,4 @@
 ﻿using AgentFramework.Core.Contracts;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.TestHarness.Utils;
 using Hyperledger.Indy.WalletApi;
 using Microsoft.Extensions.Logging;

--- a/test/AgentFramework.Core.Tests/Protocols/EphemeralChallengeTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/EphemeralChallengeTests.cs
@@ -12,7 +12,6 @@ using AgentFramework.Core.Models.Credentials;
 using AgentFramework.Core.Models.EphemeralChallenge;
 using AgentFramework.Core.Models.Proofs;
 using AgentFramework.Core.Models.Records;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.TestHarness;
 using AgentFramework.TestHarness.Utils;
 using Hyperledger.Indy.WalletApi;

--- a/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
@@ -13,7 +13,6 @@ using AgentFramework.Core.Models.Connections;
 using AgentFramework.Core.Models.Credentials;
 using AgentFramework.Core.Models.Events;
 using AgentFramework.Core.Models.Proofs;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.TestHarness;
 using AgentFramework.TestHarness.Utils;
 using Hyperledger.Indy.WalletApi;

--- a/test/AgentFramework.Core.Tests/ProvisioningServiceTests.cs
+++ b/test/AgentFramework.Core.Tests/ProvisioningServiceTests.cs
@@ -1,5 +1,4 @@
 ﻿using AgentFramework.Core.Models.Wallets;
-using AgentFramework.Core.Handlers.Agents;
 using System;
 using System.Threading.Tasks;
 using AgentFramework.Core.Runtime;

--- a/test/AgentFramework.Core.Tests/RuntimeTests.cs
+++ b/test/AgentFramework.Core.Tests/RuntimeTests.cs
@@ -1,5 +1,4 @@
-﻿using AgentFramework.AspNetCore;
-using AgentFramework.Core.Contracts;
+﻿using AgentFramework.Core.Contracts;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/AgentFramework.Core.Tests/SearchTests.cs
+++ b/test/AgentFramework.Core.Tests/SearchTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using AgentFramework.Core.Contracts;
 using AgentFramework.Core.Models.Records;
 using AgentFramework.Core.Models.Records.Search;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using Hyperledger.Indy.WalletApi;
 using Xunit;

--- a/test/AgentFramework.Core.Tests/WalletTests.cs
+++ b/test/AgentFramework.Core.Tests/WalletTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using AgentFramework.Core.Models.Wallets;
-using AgentFramework.Core.Handlers.Agents;
 using AgentFramework.Core.Runtime;
 using Hyperledger.Indy.WalletApi;
 using Xunit;


### PR DESCRIPTION
Moved service and builder extensions to Core project. They don't belong in AspNetCore project, and should be used in Xamarin or other host solutions without adding dependency to AspNetCore
Extensions also moved to Microsoft.Extensions.DependencyInjection namespace so they're immediately available for use.

Breaking change impact: medium, mostly removing/adding namespaces.