### PR TITLE
Remove global HttpMessageHandler in favor of IHttpClientFactory

### DIFF
--- a/src/AgentFramework.Core/AgentFramework.Core.csproj
+++ b/src/AgentFramework.Core/AgentFramework.Core.csproj
@@ -7,6 +7,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Stateless" Version="4.2.1" />

--- a/src/AgentFramework.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/src/AgentFramework.Core/Configuration/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddOptions<WalletOptions>();
             services.AddOptions<PoolOptions>();
             services.AddLogging();
+            services.AddHttpClient();
 
             services.AddDefaultServices();
         }
@@ -52,7 +53,6 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.TryAddSingleton<IProvisioningService, DefaultProvisioningService>();
             builder.TryAddSingleton<IMessageService, DefaultMessageService>();
             builder.TryAddSingleton<IMessageDispatcher, HttpMessageDispatcher>();
-            builder.TryAddSingleton<HttpMessageHandler, HttpClientHandler>();
             builder.TryAddSingleton<ISchemaService, DefaultSchemaService>();
             builder.TryAddSingleton<ITailsService, DefaultTailsService>();
             builder.TryAddSingleton<IWalletRecordService, DefaultWalletRecordService>();

--- a/src/AgentFramework.Core/Runtime/DefaultTailsService.cs
+++ b/src/AgentFramework.Core/Runtime/DefaultTailsService.cs
@@ -30,13 +30,13 @@ namespace AgentFramework.Core.Runtime
 
         /// <summary>Initializes a new instance of the <see cref="DefaultTailsService"/> class.</summary>
         /// <param name="ledgerService">The ledger service.</param>
-        /// <param name="httpMessageHandler">The HTTP message handler.</param>
+        /// <param name="httpClientFactory"></param>
         public DefaultTailsService(
             ILedgerService ledgerService, 
-            HttpMessageHandler httpMessageHandler)
+            IHttpClientFactory httpClientFactory)
         {
             LedgerService = ledgerService;
-            HttpClient = new HttpClient(httpMessageHandler);
+            HttpClient = httpClientFactory.CreateClient();
         }
 
         /// <inheritdoc />

--- a/src/AgentFramework.Core/Runtime/Transport/HttpMessageDispatcher.cs
+++ b/src/AgentFramework.Core/Runtime/Transport/HttpMessageDispatcher.cs
@@ -19,10 +19,10 @@ namespace AgentFramework.Core.Runtime.Transport
         /// <summary>
         /// Default constructor.
         /// </summary>
-        /// <param name="httpMessageHandler">Http message handler.</param>
-        public HttpMessageDispatcher(HttpMessageHandler httpMessageHandler)
+        /// <param name="httpClientFactory">The HTTP client factory.</param>
+        public HttpMessageDispatcher(IHttpClientFactory httpClientFactory)
         {
-            HttpClient = new HttpClient(httpMessageHandler);
+            HttpClient = httpClientFactory.CreateClient();
         }
 
         /// <inheritdoc />

--- a/src/AgentFramework.TestHarness/Mock/InProcAgent.cs
+++ b/src/AgentFramework.TestHarness/Mock/InProcAgent.cs
@@ -107,7 +107,7 @@ namespace AgentFramework.TestHarness.Mock
                                 config.PoolName = "TestPool";
                             })
                             .AddSovrinToken());
-                    services.AddSingleton(handler);
+                    services.AddSingleton<IHttpClientFactory>(new InProcFactory(handler));
                 }).Build());
 
         #endregion
@@ -131,6 +131,22 @@ namespace AgentFramework.TestHarness.Mock
             public ConnectionRecord Connection1 { get; set; }
 
             public ConnectionRecord Connection2 { get; set; }
+        }
+
+        public class InProcFactory : IHttpClientFactory
+        {
+            public InProcFactory(HttpMessageHandler handler)
+            {
+                Handler = handler;
+            }
+
+            public HttpMessageHandler Handler { get; set; }
+
+            /// <inheritdoc />
+            public HttpClient CreateClient(string name)
+            {
+                return new HttpClient(Handler);
+            }
         }
     }
 }

--- a/src/AgentFramework.TestHarness/Mock/MockUtils.cs
+++ b/src/AgentFramework.TestHarness/Mock/MockUtils.cs
@@ -21,8 +21,7 @@ namespace AgentFramework.TestHarness.Mock
             services.AddDefaultMessageHandlers();
             services.AddLogging();
             services.AddSingleton<MockAgentMessageProcessor>();
-            services.AddSingleton<HttpMessageHandler>(handler);
-            services.AddSingleton(p => new HttpClient(p.GetRequiredService<HttpMessageHandler>()));
+            services.AddSingleton<IHttpClientFactory>(new InProcAgent.InProcFactory(handler));
 
             return await CreateAsync(agentName, configuration, credentials, services, issuerSeed);
         }

--- a/test/AgentFramework.Core.Tests/ConfigurationTests.cs
+++ b/test/AgentFramework.Core.Tests/ConfigurationTests.cs
@@ -52,7 +52,6 @@ namespace AgentFramework.Core.Tests
             Assert.NotNull(container.Resolve<IMessageService>());
             Assert.NotNull(container.Resolve<ITailsService>());
             Assert.NotNull(container.Resolve<IWalletService>());
-            Assert.NotNull(container.Resolve<HttpMessageHandler>());
         }
 
         [Fact]

--- a/test/AgentFramework.Core.Tests/MessageServiceTests.cs
+++ b/test/AgentFramework.Core.Tests/MessageServiceTests.cs
@@ -65,11 +65,15 @@ namespace AgentFramework.Core.Tests
                 })
                 .Verifiable();
 
+            var clientFactory = new Mock<IHttpClientFactory>();
+            clientFactory.Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient(handlerMock.Object));
+
             var mockConnectionService = new Mock<IConnectionService>();
             mockConnectionService.Setup(_ => _.ListAsync(It.IsAny<IAgentContext>(), It.IsAny<ISearchQuery>(), It.IsAny<int>()))
                 .Returns(Task.FromResult(new List<ConnectionRecord> {new ConnectionRecord()}));
 
-            var httpMessageDispatcher = new HttpMessageDispatcher(handlerMock.Object);
+            var httpMessageDispatcher = new HttpMessageDispatcher(clientFactory.Object);
 
             _messagingService =
                 new DefaultMessageService(new Mock<ILogger<DefaultMessageService>>().Object, new[] { httpMessageDispatcher });

--- a/test/AgentFramework.Core.Tests/Protocols/CredentialTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/CredentialTests.cs
@@ -52,7 +52,11 @@ namespace AgentFramework.Core.Tests.Protocols
             var provisioning = ServiceUtils.GetDefaultMockProvisioningService();
             var paymentService = new DefaultPaymentService();
 
-            var tailsService = new DefaultTailsService(ledgerService, new HttpClientHandler());
+            var clientFactory = new Mock<IHttpClientFactory>();
+            clientFactory.Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
+            var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
             _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService,paymentService, tailsService);
 
             _connectionService = new DefaultConnectionService(

--- a/test/AgentFramework.Core.Tests/Protocols/EphemeralChallengeTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/EphemeralChallengeTests.cs
@@ -62,9 +62,13 @@ namespace AgentFramework.Core.Tests.Protocols
                 })
                 .Returns(Task.FromResult<MessageContext>(null));
 
+            var clientFactory = new Mock<IHttpClientFactory>();
+            clientFactory.Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
             var provisioningMock = ServiceUtils.GetDefaultMockProvisioningService();
             var paymentService = new DefaultPaymentService();
-            var tailsService = new DefaultTailsService(ledgerService, new HttpClientHandler());
+            var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
 
             _schemaService = new DefaultSchemaService(provisioningMock, recordService, ledgerService, paymentService, tailsService);
 

--- a/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
+++ b/test/AgentFramework.Core.Tests/Protocols/ProofTests.cs
@@ -54,7 +54,11 @@ namespace AgentFramework.Core.Tests.Protocols
             var provisioning = ServiceUtils.GetDefaultMockProvisioningService();
             var paymentService = new DefaultPaymentService();
 
-            var tailsService = new DefaultTailsService(ledgerService, new HttpClientHandler());
+            var clientFactory = new Mock<IHttpClientFactory>();
+            clientFactory.Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
+            var tailsService = new DefaultTailsService(ledgerService, clientFactory.Object);
             _schemaService = new DefaultSchemaService(provisioning, recordService, ledgerService, paymentService, tailsService);
 
             _connectionService = new DefaultConnectionService(


### PR DESCRIPTION
Allows for custom registrations to supply implementations of HttpClient with handlers instead using a global handler.